### PR TITLE
Remove "-fomit-frame-pointer" from flags. It uses by default when specif...

### DIFF
--- a/build
+++ b/build
@@ -39,7 +39,7 @@
 
 ENABLE_LANGUAGES='c,c++,fortran'
 
-BASE_CFLAGS="-O2 -pipe -fomit-frame-pointer"
+BASE_CFLAGS="-O2 -pipe"
 BASE_CXXFLAGS="$BASE_CFLAGS"
 BASE_CPPFLAGS=""
 BASE_LDFLAGS="-pipe"


### PR DESCRIPTION
...ied -O flag (http://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html)
