### PR TITLE
Update broken link

### DIFF
--- a/scripts/binutils.sh
+++ b/scripts/binutils.sh
@@ -45,7 +45,7 @@ PKG_NAME=binutils-${PKG_VERSION}
 PKG_DIR_NAME=binutils-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://mirrors.kernel.org/sources.redhat.com/binutils/releases/binutils-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/binutils/binutils-${PKG_VERSION}.tar.bz2"
 )
 
 PKG_PRIORITY=prereq


### PR DESCRIPTION
This patch fixes the broken link. But unfortunately the build is broken using gcc-4.9 or later:

```
In file included from ../../../src/binutils-2.23.2/bfd/opncls.c:26:0:
../../../src/binutils-2.23.2/bfd/opncls.c: In function 'bfd_fopen':
./bfd.h:529:65: error: right-hand operand of comma expression has no effect [-Werror=unused-value]
 #define bfd_set_cacheable(abfd,bool) (((abfd)->cacheable = bool), TRUE)
                                                                 ^
../../../src/binutils-2.23.2/bfd/opncls.c:261:5: note: in expansion of macro 'bfd_set_cacheable'
     bfd_set_cacheable (nbfd, TRUE);
     ^
cc1.exe: all warnings being treated as errors
```

I am compiling using gcc-4.9.2 which seems to emit a warning where previous gcc versions did not and due to -Werror=unused-value the build breaks. Other projects are also affect by this binutils bug e.g. https://github.com/open-power/p8-pore-binutils/issues/2.

