### PR TITLE
Fixed an issue with downloading the toolchain

### DIFF
--- a/library/functions.sh
+++ b/library/functions.sh
@@ -849,16 +849,16 @@ function func_install_toolchain {
 	# $5 - x86_64-mingw URL
 
 	[[ $USE_MULTILIB == yes ]] && {
-		local _arch_bit=both
+		local _build_arch=both
 	} || {
-		local _arch_bit=$(func_get_arch_bit $BUILD_ARCHITECTURE)
+		local _build_arch=$BUILD_ARCHITECTURE
 	}
-	case $_arch_bit in
+	case $_build_arch in
 		i686)
-			func_abstract_toolchain $1 $4 $2 $_arch_bit
+			func_abstract_toolchain $1 $4 $2 $_build_arch
 		;;
 		x86_64)
-			func_abstract_toolchain $1 $5 $3 $_arch_bit
+			func_abstract_toolchain $1 $5 $3 $_build_arch
 		;;
 		both)
 			func_abstract_toolchain $1 $4 $2 "i686"


### PR DESCRIPTION
When trying to run a build, I found that it was failing to download the toolchain.  It looks like the problem was in the func_install_toolchain function, it wasn't recognizing the toolchain for one architecture correctly.  This change modifies that behavior to correctly download the toolchain.