### PR TITLE
Change urls to not use ftp when possible

### DIFF
--- a/scripts/gcc-4.6.2.sh
+++ b/scripts/gcc-4.6.2.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
 )
 
 PKG_PRIORITY=main

--- a/scripts/gcc-4.6.3.sh
+++ b/scripts/gcc-4.6.3.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
 )	
 
 PKG_PRIORITY=main

--- a/scripts/gcc-4.6.4.sh
+++ b/scripts/gcc-4.6.4.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
 )
 PKG_PRIORITY=main
 

--- a/scripts/gcc-4.7.0.sh
+++ b/scripts/gcc-4.7.0.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
 )
 PKG_PRIORITY=main
 

--- a/scripts/gcc-4.7.1.sh
+++ b/scripts/gcc-4.7.1.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
 )
 
 PKG_PRIORITY=main

--- a/scripts/gcc-4.7.2.sh
+++ b/scripts/gcc-4.7.2.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
 )
 
 PKG_PRIORITY=main

--- a/scripts/gcc-4.7.3.sh
+++ b/scripts/gcc-4.7.3.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
 )
 
 PKG_PRIORITY=main

--- a/scripts/gcc-4.8.0.sh
+++ b/scripts/gcc-4.8.0.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
 )
 
 PKG_PRIORITY=main

--- a/scripts/gcc-4.8.1.sh
+++ b/scripts/gcc-4.8.1.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
 )
 
 PKG_PRIORITY=main

--- a/scripts/gcc-4.8.2.sh
+++ b/scripts/gcc-4.8.2.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
 )
 
 PKG_PRIORITY=main

--- a/scripts/gcc-4.8.3.sh
+++ b/scripts/gcc-4.8.3.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
 )
 
 PKG_PRIORITY=main

--- a/scripts/gcc-4.8.4.sh
+++ b/scripts/gcc-4.8.4.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
 )
 
 PKG_PRIORITY=main

--- a/scripts/gcc-4.9.0.sh
+++ b/scripts/gcc-4.9.0.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
 )
 
 PKG_PRIORITY=main

--- a/scripts/gcc-4.9.1.sh
+++ b/scripts/gcc-4.9.1.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}.tar.bz2"
 )
 
 PKG_PRIORITY=main

--- a/scripts/gcc-4.9.2.sh
+++ b/scripts/gcc-4.9.2.sh
@@ -40,7 +40,7 @@ PKG_NAME=gcc-${PKG_VERSION}
 PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}${PKG_TYPE}"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}${PKG_TYPE}"
 )
 
 PKG_PRIORITY=main

--- a/scripts/gdb.sh
+++ b/scripts/gdb.sh
@@ -40,7 +40,7 @@ PKG_NAME=gdb-${PKG_VERSION}
 PKG_DIR_NAME=gdb-${PKG_VERSION}
 PKG_TYPE=.tar.xz
 PKG_URLS=(
-	"ftp://ftp.gnu.org/gnu/gdb/gdb-${PKG_VERSION}${PKG_TYPE}"
+	"https://ftp.gnu.org/gnu/gdb/gdb-${PKG_VERSION}${PKG_TYPE}"
 )
 
 PKG_PRIORITY=main

--- a/scripts/gdbm.sh
+++ b/scripts/gdbm.sh
@@ -40,7 +40,7 @@ PKG_NAME=gdbm-${PKG_VERSION}
 PKG_DIR_NAME=gdbm-${PKG_VERSION}
 PKG_TYPE=.tar.gz
 PKG_URLS=(
-	"ftp://ftp.gnu.org/gnu/gdbm/gdbm-${PKG_VERSION}.tar.gz"
+	"https://ftp.gnu.org/gnu/gdbm/gdbm-${PKG_VERSION}.tar.gz"
 )
 PKG_PRIORITY=extra
 

--- a/scripts/libiconv.sh
+++ b/scripts/libiconv.sh
@@ -40,7 +40,7 @@ PKG_NAME=$PKG_ARCHITECTURE-libiconv-$LINK_TYPE_SUFFIX
 PKG_DIR_NAME=libiconv-${PKG_VERSION}
 PKG_TYPE=.tar.gz
 PKG_URLS=(
-	"http://ftp.gnu.org/pub/gnu/libiconv/libiconv-${PKG_VERSION}.tar.gz"
+	"https://ftp.gnu.org/pub/gnu/libiconv/libiconv-${PKG_VERSION}.tar.gz"
 )
 
 PKG_PRIORITY=prereq

--- a/scripts/make.sh
+++ b/scripts/make.sh
@@ -40,7 +40,7 @@ PKG_NAME=make-${PKG_VERSION}
 PKG_DIR_NAME=make-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.gnu.org/gnu/make/make-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/make/make-${PKG_VERSION}.tar.bz2"
 )
 
 PKG_PRIORITY=extra

--- a/scripts/mpfr.sh
+++ b/scripts/mpfr.sh
@@ -40,7 +40,7 @@ PKG_NAME=$BUILD_ARCHITECTURE-mpfr-${PKG_VERSION}-$LINK_TYPE_SUFFIX
 PKG_DIR_NAME=mpfr-${PKG_VERSION}
 PKG_TYPE=.tar.bz2
 PKG_URLS=(
-	"ftp://ftp.gnu.org/gnu/mpfr/mpfr-${PKG_VERSION}.tar.bz2"
+	"https://ftp.gnu.org/gnu/mpfr/mpfr-${PKG_VERSION}.tar.bz2"
 )
 
 PKG_PRIORITY=prereq

--- a/scripts/ncurses.sh
+++ b/scripts/ncurses.sh
@@ -40,7 +40,7 @@ PKG_NAME=ncurses-${PKG_VERSION}
 PKG_DIR_NAME=ncurses-${PKG_VERSION}
 PKG_TYPE=.tar.gz
 PKG_URLS=(
-	"ftp://invisible-island.net/ncurses/ncurses-${PKG_VERSION}.tar.gz"
+	"https://ftp.gnu.org/gnu/ncurses/ncurses-${PKG_VERSION}.tar.gz"
 )
 
 PKG_PRIORITY=extra

--- a/scripts/readline.sh
+++ b/scripts/readline.sh
@@ -40,7 +40,7 @@ PKG_NAME=readline-${PKG_VERSION}
 PKG_DIR_NAME=readline-${PKG_VERSION}
 PKG_TYPE=.tar.gz
 PKG_URLS=(
-	"ftp://ftp.gnu.org/gnu/readline/readline-${PKG_VERSION}.tar.gz"
+	"https://ftp.gnu.org/gnu/readline/readline-${PKG_VERSION}.tar.gz"
 )
 
 PKG_PRIORITY=extra

--- a/scripts/termcap.sh
+++ b/scripts/termcap.sh
@@ -40,7 +40,7 @@ PKG_NAME=termcap-${PKG_VERSION}
 PKG_DIR_NAME=termcap-${PKG_VERSION}
 PKG_TYPE=.tar.gz
 PKG_URLS=(
-	"ftp://ftp.gnu.org/gnu/termcap/termcap-${PKG_VERSION}.tar.gz"
+	"https://ftp.gnu.org/gnu/termcap/termcap-${PKG_VERSION}.tar.gz"
 )
 
 PKG_PRIORITY=extra

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -174,15 +174,13 @@ func_test \
 
 # **************************************************************************
 
-[[ $BUILD_VERSION == 4.6.? ]] || {
-	list11=(
-		"random_device.cpp -std=c++0x -o random_device.exe"
-	)
+list11=(
+	"random_device.cpp -std=c++0x -o random_device.exe"
+)
 
-	func_test \
-		"random_device" \
-		list11[@] \
-		$TESTS_ROOT_DIR
-}
+func_test \
+	"random_device" \
+	list11[@] \
+	$TESTS_ROOT_DIR
 
 # **************************************************************************

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -174,13 +174,15 @@ func_test \
 
 # **************************************************************************
 
-list11=(
-	"random_device.cpp -std=c++0x -o random_device.exe"
-)
+[[ $BUILD_VERSION == 4.6.? ]] || {
+	list11=(
+		"random_device.cpp -std=c++0x -o random_device.exe"
+	)
 
-func_test \
-	"random_device" \
-	list11[@] \
-	$TESTS_ROOT_DIR
+	func_test \
+		"random_device" \
+		list11[@] \
+		$TESTS_ROOT_DIR
+}
 
 # **************************************************************************


### PR DESCRIPTION
I've been having issues downloading from ftp://ftp.gnu.org - wget doesn't like the EPSV response (or whatever it was).  If I use https://ftp.gnu.org instead, things work fine.  So I when through the scripts directory and pointed as many ftp:// urls to a web server when possible.  I also moved as many things to ftp.gnu.org as I could instead of rely on random mirrors at times.