### PR TITLE
Texinfo is required for binutils

### DIFF
--- a/library/config-win.sh
+++ b/library/config-win.sh
@@ -92,6 +92,7 @@ function func_test_installed_packages {
 		gettext-devel
 		wget
 		sshpass
+		texinfo
 	)
 
 	for it in ${packages[@]}; do


### PR DESCRIPTION
When setting up my environment, I found that unless I had texinfo installed, binutils would fail because it tried to run makeinfo.  Some of the comments and wording around the failure seemed to imply that makeinfo was only needed if certain files had been modified, but I kept getting errors until I added it, so I added it to the list of required packages.