### PR TITLE
Support building a specific release of mingw-w64

### DIFF
--- a/build
+++ b/build
@@ -64,7 +64,9 @@ readonly RUN_ARGS="$@"
 	echo "    --static-gcc               - build static GCC"
 	echo "    --dyn-deps                 - build GCC with dynamically dependencies"
 	echo "    --jobs=N                   - specifies number of parallel make threads"
-	echo "    --rt-version=<v3|v4|trunk> - specifies mingw-w64 runtime version to build"
+	echo "    --rt-version=<v3|v4|trunk|<release>> - specifies mingw-w64 runtime version to build"
+	echo "                                 v3, v4, trunk specify specific branches in the git repo"
+	echo "                                 <release> is a specific release version, uses the tarball"
 	echo "    --rev=N                    - specifies number of the build revision"
 	echo "    --threads=<model>          - specifies the threads model for GCC/libstdc++"
 	echo "                                 available: win32, posix"
@@ -229,7 +231,7 @@ while [[ $# > 0 ]]; do
 					RUNTIME_VERSION=v4
 					RUNTIME_BRANCH="master"
 				;;
-				v3.3.0)
+				v?.?.?)
 					RUNTIME_BRANCH="release"
 				;;
 				*)
@@ -379,7 +381,8 @@ func_install_toolchain \
 	GCC_PART_NAME=${GCC_NAME/gcc-/}
 	GCC_PART_NAME=${GCC_PART_NAME/-branch/b}
 	readonly GCC_PART_NAME=${GCC_PART_NAME//./}
-	BASE_BUILD_DIR=$ROOT_DIR/${BUILD_ARCHITECTURE}-$GCC_PART_NAME-$THREADS_MODEL-$EXCEPTIONS_MODEL-rt_${RUNTIME_VERSION}${REV_STRING}
+	readonly RUNTIME_PART_NAME=${RUNTIME_VERSION//./}
+	BASE_BUILD_DIR=$ROOT_DIR/${BUILD_ARCHITECTURE}-$GCC_PART_NAME-$THREADS_MODEL-$EXCEPTIONS_MODEL-rt_${RUNTIME_PART_NAME}${REV_STRING}
 	MINGW_BUILD_NAME=${BUILD_ARCHITECTURE}-${GCC_NAME/gcc-/}
 	[[ $BUILD_SHARED_GCC == no ]] && {
 		BASE_BUILD_DIR=$BASE_BUILD_DIR-s

--- a/build
+++ b/build
@@ -229,6 +229,9 @@ while [[ $# > 0 ]]; do
 					RUNTIME_VERSION=v4
 					RUNTIME_BRANCH="master"
 				;;
+				v3.3.0)
+					RUNTIME_BRANCH="release"
+				;;
 				*)
 					die "Unsupported runtime version $RUNTIME_VERSION."
 				;;

--- a/library/subtargets.sh
+++ b/library/subtargets.sh
@@ -56,6 +56,7 @@ function func_get_subtargets {
 		$( [[ $2 == 4.6.? || $2 == 4.7.? ]] && echo ppl )
 		isl
 		cloog
+		mingw-w64-download
 		mingw-w64-api
 		mingw-w64-crt
 		$( \

--- a/library/subtargets.sh
+++ b/library/subtargets.sh
@@ -98,6 +98,17 @@ function func_get_subtargets {
 		binutils-post
 		$GCC_NAME
 		gcc-post
+		mingw-w64-libraries-libmangle
+		#mingw-w64-libraries-pseh
+		mingw-w64-tools-gendef
+		mingw-w64-tools-genidl
+		mingw-w64-tools-genpeimg
+		mingw-w64-tools-widl
+		${PYTHON_SUBTARGETS[@]}
+		gdbinit
+		gdb
+		gdb-wrapper
+		make
 		3rdparty-post
 		cleanup
 		licenses

--- a/library/subtargets.sh
+++ b/library/subtargets.sh
@@ -97,17 +97,6 @@ function func_get_subtargets {
 		binutils-post
 		$GCC_NAME
 		gcc-post
-		mingw-w64-libraries-libmangle
-		#mingw-w64-libraries-pseh
-		mingw-w64-tools-gendef
-		mingw-w64-tools-genidl
-		mingw-w64-tools-genpeimg
-		mingw-w64-tools-widl
-		${PYTHON_SUBTARGETS[@]}
-		gdbinit
-		gdb
-		gdb-wrapper
-		make
 		3rdparty-post
 		cleanup
 		licenses

--- a/scripts/binutils.sh
+++ b/scripts/binutils.sh
@@ -92,7 +92,7 @@ PKG_CONFIGURE_FLAGS=(
 	--enable-gold
 	--enable-install-libiberty
 	#
-	--with-libiconv-prefix=$PREREQ_DIR/libiconv-$BUILD_ARCHITECTURE
+	--with-libiconv-prefix=$PREREQ_DIR/$BUILD_ARCHITECTURE-libiconv-$LINK_TYPE_SUFFIX
 	#
 	--disable-rpath
 	--disable-nls

--- a/scripts/mingw-w64-api.sh
+++ b/scripts/mingw-w64-api.sh
@@ -36,16 +36,11 @@
 # **************************************************************************
 
 PKG_NAME=mingw-w64-headers-${RUNTIME_VERSION}
+PKG_DIR_NAME=mingw-w64${MINGW_PKG_DIR_VERSION_SUFFIX}/mingw-w64-headers
 [[ $USE_MULTILIB == yes ]] && {
 	PKG_NAME=$BUILD_ARCHITECTURE-$PKG_NAME-multi
 } || {
 	PKG_NAME=$BUILD_ARCHITECTURE-$PKG_NAME-nomulti
-}
-
-[[ $RUNTIME_BRANCH == release ]] && {
-	PKG_DIR_NAME=mingw-w64-${RUNTIME_VERSION}/mingw-w64-headers
-} || {
-	PKG_DIR_NAME=mingw-w64/mingw-w64-headers
 }
 
 PKG_PRIORITY=runtime

--- a/scripts/mingw-w64-api.sh
+++ b/scripts/mingw-w64-api.sh
@@ -41,11 +41,20 @@ PKG_NAME=mingw-w64-headers-${RUNTIME_VERSION}
 } || {
 	PKG_NAME=$BUILD_ARCHITECTURE-$PKG_NAME-nomulti
 }
-PKG_DIR_NAME=mingw-w64/mingw-w64-headers
-PKG_TYPE=git
-PKG_URLS=(
-	"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
-)
+
+[[ $RUNTIME_BRANCH == release ]] && {
+	PKG_DIR_NAME=mingw-w64-${RUNTIME_VERSION}/mingw-w64-headers
+	PKG_TYPE=.tar.bz2
+	PKG_URLS=(
+		"http://downloads.sourceforge.net/project/mingw-w64/mingw-w64-release/mingw-w64-${RUNTIME_VERSION}.tar.bz2"
+	)
+} || {
+	PKG_DIR_NAME=mingw-w64/mingw-w64-headers
+	PKG_TYPE=git
+	PKG_URLS=(
+		"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
+	)
+}
 
 PKG_PRIORITY=runtime
 

--- a/scripts/mingw-w64-crt.sh
+++ b/scripts/mingw-w64-crt.sh
@@ -44,16 +44,8 @@ PKG_NAME=mingw-w64-crt-${RUNTIME_VERSION}
 
 [[ $RUNTIME_BRANCH == release ]] && {
 	PKG_DIR_NAME=mingw-w64-${RUNTIME_VERSION}/mingw-w64-crt
-	PKG_TYPE=.tar.bz2
-	PKG_URLS=(
-		"http://downloads.sourceforge.net/project/mingw-w64/mingw-w64-release/mingw-w64-${RUNTIME_VERSION}.tar.bz2"
-	)
 } || {
 	PKG_DIR_NAME=mingw-w64/mingw-w64-crt
-	PKG_TYPE=git
-	PKG_URLS=(
-		"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
-	)
 }
 
 PKG_PRIORITY=runtime

--- a/scripts/mingw-w64-crt.sh
+++ b/scripts/mingw-w64-crt.sh
@@ -36,16 +36,12 @@
 # **************************************************************************
 
 PKG_NAME=mingw-w64-crt-${RUNTIME_VERSION}
+PKG_DIR_NAME=mingw-w64${MINGW_PKG_DIR_VERSION_SUFFIX}/mingw-w64-crt
+
 [[ $USE_MULTILIB == yes ]] && {
 	PKG_NAME=$BUILD_ARCHITECTURE-$PKG_NAME-multi
 } || {
 	PKG_NAME=$BUILD_ARCHITECTURE-$PKG_NAME-nomulti
-}
-
-[[ $RUNTIME_BRANCH == release ]] && {
-	PKG_DIR_NAME=mingw-w64-${RUNTIME_VERSION}/mingw-w64-crt
-} || {
-	PKG_DIR_NAME=mingw-w64/mingw-w64-crt
 }
 
 PKG_PRIORITY=runtime

--- a/scripts/mingw-w64-crt.sh
+++ b/scripts/mingw-w64-crt.sh
@@ -41,11 +41,20 @@ PKG_NAME=mingw-w64-crt-${RUNTIME_VERSION}
 } || {
 	PKG_NAME=$BUILD_ARCHITECTURE-$PKG_NAME-nomulti
 }
-PKG_DIR_NAME=mingw-w64/mingw-w64-crt
-PKG_TYPE=git
-PKG_URLS=(
-	"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
-)
+
+[[ $RUNTIME_BRANCH == release ]] && {
+	PKG_DIR_NAME=mingw-w64-${RUNTIME_VERSION}/mingw-w64-crt
+	PKG_TYPE=.tar.bz2
+	PKG_URLS=(
+		"http://downloads.sourceforge.net/project/mingw-w64/mingw-w64-release/mingw-w64-${RUNTIME_VERSION}.tar.bz2"
+	)
+} || {
+	PKG_DIR_NAME=mingw-w64/mingw-w64-crt
+	PKG_TYPE=git
+	PKG_URLS=(
+		"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
+	)
+}
 
 PKG_PRIORITY=runtime
 
@@ -53,7 +62,7 @@ PKG_PRIORITY=runtime
 
 PKG_PATCHES=(
 	$( \
-		[[ $RUNTIME_VERSION == v3 ]] && { \
+		[[ ($RUNTIME_VERSION == v3) || ($RUNTIME_VERSION == v3.3.0) ]] && { \
 			echo "mingw-w64/6385.patch"; \
 			echo "mingw-w64/6386.patch"; \
 			echo "mingw-w64/6390.patch"; \

--- a/scripts/mingw-w64-crt.sh
+++ b/scripts/mingw-w64-crt.sh
@@ -53,8 +53,8 @@ PKG_PRIORITY=runtime
 #
 
 PKG_PATCHES=(
-	$( \
-		[[ ($RUNTIME_VERSION == v3) || ($RUNTIME_VERSION == v3.3.0) ]] && { \
+	$(
+		[[ $RUNTIME_VERSION == v3 ]] && { \
 			echo "mingw-w64/6385.patch"; \
 			echo "mingw-w64/6386.patch"; \
 			echo "mingw-w64/6390.patch"; \

--- a/scripts/mingw-w64-download.sh
+++ b/scripts/mingw-w64-download.sh
@@ -38,17 +38,19 @@
 PKG_NAME=mingw-w64-${RUNTIME_VERSION}
 
 [[ $RUNTIME_BRANCH == release ]] && {
-	PKG_DIR_NAME=mingw-w64-${RUNTIME_VERSION}
+	MINGW_PKG_DIR_VERSION_SUFFIX="-${RUNTIME_VERSION}"
 	PKG_TYPE=.tar.bz2
 	PKG_URLS=(
 		"http://downloads.sourceforge.net/project/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-${RUNTIME_VERSION}.tar.bz2"
 	)
 } || {
-	PKG_DIR_NAME=mingw-w64
+	MINGW_PKG_DIR_VERSION_SUFFIX=""
 	PKG_TYPE=git
 	PKG_URLS=(
 		"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
 	)
 }
+
+PKG_DIR_NAME=mingw-w64${MINGW_PKG_DIR_VERSION_SUFFIX}
 
 PKG_PRIORITY=runtime

--- a/scripts/mingw-w64-download.sh
+++ b/scripts/mingw-w64-download.sh
@@ -35,61 +35,20 @@
 
 # **************************************************************************
 
-PKG_NAME=mingw-w64-headers-${RUNTIME_VERSION}
-[[ $USE_MULTILIB == yes ]] && {
-	PKG_NAME=$BUILD_ARCHITECTURE-$PKG_NAME-multi
-} || {
-	PKG_NAME=$BUILD_ARCHITECTURE-$PKG_NAME-nomulti
-}
+PKG_NAME=mingw-w64-${RUNTIME_VERSION}
 
 [[ $RUNTIME_BRANCH == release ]] && {
-	PKG_DIR_NAME=mingw-w64-${RUNTIME_VERSION}/mingw-w64-headers
+	PKG_DIR_NAME=mingw-w64-${RUNTIME_VERSION}
+	PKG_TYPE=.tar.bz2
+	PKG_URLS=(
+		"http://downloads.sourceforge.net/project/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-${RUNTIME_VERSION}.tar.bz2"
+	)
 } || {
-	PKG_DIR_NAME=mingw-w64/mingw-w64-headers
+	PKG_DIR_NAME=mingw-w64
+	PKG_TYPE=git
+	PKG_URLS=(
+		"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
+	)
 }
 
 PKG_PRIORITY=runtime
-
-#
-
-PKG_PATCHES=()
-
-#
-
-[[ $USE_MULTILIB == yes ]] && {
-	RUNTIMEPREFIX=$RUNTIME_DIR/$BUILD_ARCHITECTURE-mingw-w64-${RUNTIME_VERSION}-multi
-} || {
-	RUNTIMEPREFIX=$RUNTIME_DIR/$BUILD_ARCHITECTURE-mingw-w64-${RUNTIME_VERSION}-nomulti
-}
-
-PKG_CONFIGURE_FLAGS=(
-	--host=$HOST
-	--build=$BUILD
-	--target=$TARGET
-	#
-	--prefix=$RUNTIMEPREFIX
-	#
-	--enable-sdk=all
-	--enable-secure-api
-	#
-	CFLAGS="\"$COMMON_CFLAGS\""
-	CXXFLAGS="\"$COMMON_CXXFLAGS\""
-	CPPFLAGS="\"$COMMON_CPPFLAGS\""
-	LDFLAGS="\"$COMMON_LDFLAGS\""
-)
-
-#
-
-PKG_MAKE_FLAGS=(
-	-j$JOBS
-	all
-)
-
-#
-
-PKG_INSTALL_FLAGS=(
-	-j$JOBS
-	$( [[ $STRIP_ON_INSTALL == yes ]] && echo install-strip || echo install )
-)
-
-# **************************************************************************

--- a/scripts/mingw-w64-libraries-libmangle.sh
+++ b/scripts/mingw-w64-libraries-libmangle.sh
@@ -36,14 +36,8 @@
 # **************************************************************************
 
 PKG_NAME=libmangle-${RUNTIME_VERSION}
-PKG_DIR_NAME=libmangle-${RUNTIME_VERSION}
-PKG_DIR_NAME=mingw-w64/mingw-w64-libraries/libmangle
-PKG_TYPE=git
-PKG_URLS=(
-	"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
-)
+PKG_DIR_NAME=mingw-w64${MINGW_PKG_DIR_VERSION_SUFFIX}/mingw-w64-libraries/libmangle
 
-PKG_REVISION=
 PKG_PRIORITY=extra
 
 #

--- a/scripts/mingw-w64-tools-gendef.sh
+++ b/scripts/mingw-w64-tools-gendef.sh
@@ -36,12 +36,7 @@
 # **************************************************************************
 
 PKG_NAME=gendef-${RUNTIME_VERSION}
-PKG_DIR_NAME=gendef-${RUNTIME_VERSION}
-PKG_DIR_NAME=mingw-w64/mingw-w64-tools/gendef
-PKG_TYPE=git
-PKG_URLS=(
-	"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
-)
+PKG_DIR_NAME=mingw-w64${MINGW_PKG_DIR_VERSION_SUFFIX}/mingw-w64-tools/gendef
 
 PKG_PRIORITY=extra
 

--- a/scripts/mingw-w64-tools-genidl.sh
+++ b/scripts/mingw-w64-tools-genidl.sh
@@ -36,12 +36,7 @@
 # **************************************************************************
 
 PKG_NAME=genidl-${RUNTIME_VERSION}
-PKG_DIR_NAME=genidl-${RUNTIME_VERSION}
-PKG_DIR_NAME=mingw-w64/mingw-w64-tools/genidl
-PKG_TYPE=git
-PKG_URLS=(
-	"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
-)
+PKG_DIR_NAME=mingw-w64${MINGW_PKG_DIR_VERSION_SUFFIX}/mingw-w64-tools/genidl
 
 PKG_PRIORITY=extra
 

--- a/scripts/mingw-w64-tools-genpeimg.sh
+++ b/scripts/mingw-w64-tools-genpeimg.sh
@@ -36,12 +36,7 @@
 # **************************************************************************
 
 PKG_NAME=genpeimg-${RUNTIME_VERSION}
-PKG_DIR_NAME=genpeimg-${RUNTIME_VERSION}
-PKG_DIR_NAME=mingw-w64/mingw-w64-tools/genpeimg
-PKG_TYPE=git
-PKG_URLS=(
-	"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
-)
+PKG_DIR_NAME=mingw-w64${MINGW_PKG_DIR_VERSION_SUFFIX}/mingw-w64-tools/genpeimg
 
 PKG_PRIORITY=extra
 

--- a/scripts/mingw-w64-tools-widl.sh
+++ b/scripts/mingw-w64-tools-widl.sh
@@ -36,12 +36,7 @@
 # **************************************************************************
 
 PKG_NAME=widl-${RUNTIME_VERSION}
-PKG_DIR_NAME=widl-${RUNTIME_VERSION}
-PKG_DIR_NAME=mingw-w64/mingw-w64-tools/widl
-PKG_TYPE=git
-PKG_URLS=(
-	"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
-)
+PKG_DIR_NAME=mingw-w64${MINGW_PKG_DIR_VERSION_SUFFIX}/mingw-w64-tools/widl
 
 PKG_PRIORITY=extra
 

--- a/scripts/winpthreads.sh
+++ b/scripts/winpthreads.sh
@@ -35,11 +35,20 @@
 # **************************************************************************
 
 PKG_NAME=${PKG_ARCHITECTURE}-winpthreads-${RUNTIME_VERSION}
-PKG_DIR_NAME=mingw-w64/mingw-w64-libraries/winpthreads
-PKG_TYPE=git
-PKG_URLS=(
-	"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
-)
+
+[[ $RUNTIME_BRANCH == release ]] && {
+	PKG_DIR_NAME=mingw-w64-${RUNTIME_VERSION}/mingw-w64-libraries/winpthreads
+	PKG_TYPE=.tar.bz2
+	PKG_URLS=(
+		"http://downloads.sourceforge.net/project/mingw-w64/mingw-w64-release/mingw-w64-${RUNTIME_VERSION}.tar.bz2"
+	)
+} || {
+	PKG_DIR_NAME=mingw-w64/mingw-w64-libraries/winpthreads
+	PKG_TYPE=git
+	PKG_URLS=(
+		"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
+	)
+}
 
 PKG_PRIORITY=runtime
 

--- a/scripts/winpthreads.sh
+++ b/scripts/winpthreads.sh
@@ -38,16 +38,8 @@ PKG_NAME=${PKG_ARCHITECTURE}-winpthreads-${RUNTIME_VERSION}
 
 [[ $RUNTIME_BRANCH == release ]] && {
 	PKG_DIR_NAME=mingw-w64-${RUNTIME_VERSION}/mingw-w64-libraries/winpthreads
-	PKG_TYPE=.tar.bz2
-	PKG_URLS=(
-		"http://downloads.sourceforge.net/project/mingw-w64/mingw-w64-release/mingw-w64-${RUNTIME_VERSION}.tar.bz2"
-	)
 } || {
 	PKG_DIR_NAME=mingw-w64/mingw-w64-libraries/winpthreads
-	PKG_TYPE=git
-	PKG_URLS=(
-		"git://git.code.sf.net/p/mingw-w64/mingw-w64|branch:$RUNTIME_BRANCH|repo:$PKG_TYPE"
-	)
 }
 
 PKG_PRIORITY=runtime


### PR DESCRIPTION
Added logic to support building a specific release of mingw-w64 instead of always building from the head of the git repository.  In order to simplify some of the logic, I moved the downloading step to a separate subtarget.