### PR TITLE
Changes to not requiring running in same folder

### DIFF
--- a/build
+++ b/build
@@ -36,14 +36,14 @@
 
 # **************************************************************************
 
-# Loading functions
-source library/functions.sh
-
 readonly ORIGINAL_PATH=$PATH
-readonly TOP_DIR=$(func_simplify_path "$PWD")
+readonly TOP_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+# Loading functions
+source $TOP_DIR/library/functions.sh
 
 # Loading configuration
-source library/config.sh
+source $TOP_DIR/library/config.sh
 
 # **************************************************************************
 


### PR DESCRIPTION
I've been working on running the build as part of a CI project, and it's not finding some of the scripts correctly due to oddities of path.  These changes calculate the top dir before loading any scripts so they can be found correctly.