### PR TITLE
Corrected minor issue with dwarfseh exceptions arg

### DIFF
--- a/build
+++ b/build
@@ -150,13 +150,13 @@ while [[ $# > 0 ]]; do
 			case $BUILD_ARCHITECTURE in
 				i686)
 					case $EXCEPTIONS_MODEL in
-						dwarf|sjlj) ;;
+						dwarf|sjlj|dwarfseh) ;;
 						*) die "\"$BUILD_ARCHITECTURE\" is not valid architecture model for exception model \"$EXCEPTIONS_MODEL\". terminate." ;;
 					esac
 				;;
 				x86_64)
 					case $EXCEPTIONS_MODEL in
-						seh|sjlj) ;;
+						seh|sjlj|dwarfseh) ;;
 						*) die "\"$BUILD_ARCHITECTURE\" is not valid architecture model for exception model \"$EXCEPTIONS_MODEL\". terminate." ;;
 					esac
 				;;


### PR DESCRIPTION
I missed this when adding the dwarfseh option, I think it's dependent on the argument order, but it wasn't recognizing it as a valid exception model for either architecture.