### PR TITLE
Make GDB an extra package instead of main

### DIFF
--- a/library/functions.sh
+++ b/library/functions.sh
@@ -536,7 +536,7 @@ function func_execute {
 	((_index=${#_commands[@]}-1))
 	local _cmd_marker_name=$1/$2/exec-$4-$_index.marker
 	[[ -f $_cmd_marker_name ]] && {
-		echo "---> executed"
+		echo "---> $4 executed"
 		return $_result
 	}
 	_index=0

--- a/scripts/gdb-wrapper.sh
+++ b/scripts/gdb-wrapper.sh
@@ -35,21 +35,27 @@
 
 # **************************************************************************
 
-[[ ! -f $BUILDS_DIR/gdb-wrapper.marker ]] && {
-	mkdir -p $BUILDS_DIR/gdb-wrapper
-	cd $BUILDS_DIR/gdb-wrapper
-	echo -n "--> building..."
-	$HOST-gcc ${COMMON_CFLAGS} -U_DEBUG -o gdb.exe ${SOURCES_DIR}/gdb-wrapper/gdb-wrapper.c || { die "cannot build gdb-wrapper.exe"; }
-	echo " done"
-	echo -n "--> installing..."
+PKG_NAME=gdb-wrapper
+PKG_DIR_NAME=gdb-wrapper
+PKG_PRIORITY=extra
+
+PKG_MAKE_PROG=$HOST-gcc
+PKG_MAKE_FLAGS=(
+	${COMMON_CFLAGS}
+	-U_DEBUG
+	-o gdb.exe
+	${SOURCES_DIR}/gdb-wrapper/gdb-wrapper.c
+)
+
+PKG_EXECUTE_AFTER_INSTALL=(
+	gdb_wrapper_install_script
+)
+
+function gdb_wrapper_install_script {
 	[[ ! -f $PREFIX/bin/gdborig.exe ]] && {
 		mv $PREFIX/bin/gdb.exe $PREFIX/bin/gdborig.exe
 	}
 	cp -f gdb.exe $PREFIX/bin || die "Cannot copy gdb.exe to $PREFIX/bin"
-	echo " done"
-	touch $BUILDS_DIR/gdb-wrapper.marker
-} || {
-	echo "---> installed"
 }
 
 # **************************************************************************

--- a/scripts/gdb.sh
+++ b/scripts/gdb.sh
@@ -43,7 +43,7 @@ PKG_URLS=(
 	"https://ftp.gnu.org/gnu/gdb/gdb-${PKG_VERSION}${PKG_TYPE}"
 )
 
-PKG_PRIORITY=main
+PKG_PRIORITY=extra
 
 #
 

--- a/scripts/gdbinit.sh
+++ b/scripts/gdbinit.sh
@@ -35,11 +35,17 @@
 
 # **************************************************************************
 
-[[ ! -d $PREFIX/etc ]] && mkdir -p $PREFIX/etc
+PKG_NAME=gdbinit
+PKG_DIR_NAME=gdbinit
+PKG_PRIORITY=extra
 
-[[ ! -f $BUILDS_DIR/gbinit.marker ]] && {
+PKG_EXECUTE_AFTER_INSTALL=(
+	gdbinit_script
+)
+
+function gdbinit_script {
+	mkdir -p $PREFIX/etc
 	cat $TOP_DIR/sources/gdbinit | sed 's|%GCC_NAME%|'$GCC_NAME'|g' > $PREFIX/etc/gdbinit
-	touch $BUILDS_DIR/gdbinit.marker
 }
 
 # **************************************************************************


### PR DESCRIPTION
GDB relies on a few of the extra packages in order to build itself, so I've marked it as extra.

Also, I changed gdbinit and gdb-wrapper to tie into the normal build steps instead of being custom scripts, this way they can also be marked as extra