### PR TITLE
Remove log dirs from patch and execute commands

### DIFF
--- a/build
+++ b/build
@@ -611,7 +611,6 @@ for rule in ${SUBTARGETS[@]}; do
 			$PKG_DIR_NAME \
 			"execute commands..." \
 			"after_unpack" \
-			$CURR_LOGS_DIR \
 			PKG_EXECUTE_AFTER_UNCOMPRESS[@]
 	}
 	
@@ -620,7 +619,6 @@ for rule in ${SUBTARGETS[@]}; do
 			func_apply_patches \
 				$SRCS_DIR \
 				$PKG_DIR_NAME \
-				$CURR_LOGS_DIR \
 				$PATCHES_DIR \
 				PKG_PATCHES[@]
 		}
@@ -631,7 +629,6 @@ for rule in ${SUBTARGETS[@]}; do
 				$PKG_DIR_NAME \
 				"execute commands..." \
 				"after_patch" \
-				$CURR_LOGS_DIR \
 				PKG_EXECUTE_AFTER_PATCH[@]
 		}
 	}
@@ -660,7 +657,6 @@ for rule in ${SUBTARGETS[@]}; do
 				$PKG_NAME \
 				"execute commands..." \
 				"after_configure" \
-				$CURR_LOGS_DIR \
 				PKG_EXECUTE_AFTER_CONFIGURE[@]
 		}
 
@@ -696,7 +692,6 @@ for rule in ${SUBTARGETS[@]}; do
 				$PKG_NAME \
 				"execute commands..." \
 				"after_install" \
-				$CURR_LOGS_DIR \
 				PKG_EXECUTE_AFTER_INSTALL[@]
 		}
 

--- a/library/functions.sh
+++ b/library/functions.sh
@@ -525,11 +525,10 @@ function func_execute {
 	# $2 - src dir name
 	# $3 - message
 	# $4 - log suffix
-	# $5 - log dir
-	# $6 - commands list
+	# $5 - commands list
 
 	local _result=0
-	local -a _commands=( "${!6}" )
+	local -a _commands=( "${!5}" )
 	local it=
 	
 	local _index=0
@@ -579,15 +578,14 @@ function func_execute {
 function func_apply_patches {
 	# $1 - srcs dir name
 	# $2 - src dir name
-	# $3 - logs dir
-	# $4 - patches dir
-	# $5 - patches list
+	# $3 - patches dir
+	# $4 - patches list
 	
 	local _result=0
 	local it=
 	local applevel=
 	local _index=0
-	local -a _list=( "${!5}" )
+	local -a _list=( "${!4}" )
 	[[ ${#_list[@]} == 0 ]] && return 0
 
 	((_index=${#_list[@]}-1))
@@ -600,28 +598,28 @@ function func_apply_patches {
 	[[ ${#_list[@]} > 0 ]] && {
 		echo -n "--> patching..."
 	}
-
-	for it in ${_list[@]} ; do
+	
+	for it in ${_list[@]} ; do		
 		local _patch_marker_name=$1/$2/_patch-$_index.marker
 		local _patch_log_name=$1/$2/patch-$_index.log
+		local _patch_file=$3/${it}
 
 		[[ ! -f $_patch_marker_name ]] && {
-			[[ -f $PATCHES_DIR/${it} ]] || die "Patch $4/${it} not found!"
+			[[ -f $_patch_file ]] || die "Patch $_patch_file not found!"
 			local _level=
 			local _found=no
 			pushd $1/$2 > /dev/null
 			for _level in 0 1 2 3; do
 				local _applevel=$_level
-				patch -p$_level --dry-run -i $4/${it} > $_patch_log_name 2>&1
+				patch -p$_level --dry-run -i $_patch_file > $_patch_log_name 2>&1
 				_result=$?
 				[[ $_result == 0 ]] && {
 					_found=yes
 					break
 				}
 			done
-			#echo "patch=\"${it}\", _found=$_found, _applevel=$_applevel"
 			[[ $_found == yes ]] && {
-				patch -p$_applevel -i $4/${it} > $_patch_log_name 2>&1
+				patch -p$_applevel -i $_patch_file > $_patch_log_name 2>&1
 				_result=$?
 				[[ $_result == 0 ]] && {
 					touch $_patch_marker_name


### PR DESCRIPTION
They weren't being referenced and ended up empty when fetching, so then the array of patches or commands didn't get passed correctly and didn't apply until an actual build got ran instead.  Means that the src directory changes during a build so parallel script runs for different architectures may not work correctly.