### PR TITLE
Patch line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,8 @@
 build text eol=lf
 *.sh text eol=lf
 
+# Patch complains about stripping off trailing CR's
+*.patch text eol=lf
+
 # Windows-specific files
 *.bat text eol=crlf


### PR DESCRIPTION
I noticed that my patch-*.log files have a lot of complaints about ignore CR in the file, so I figured they should probably have just a LF for the line ending instead of the CRLF value that my computer likes to use as a default.  Added that to .gitattributes and those warnings are gone now.