### PR TITLE
Some fixes for building GCC 4.6-4.8

### DIFF
--- a/library/subtargets.sh
+++ b/library/subtargets.sh
@@ -53,7 +53,7 @@ function func_get_subtargets {
 		gmp
 		mpfr
 		mpc
-		$( [[ $2 == 4.6.? || $2 == 4.7.? ]] && echo ppl )
+		$( [[ $2 == 4.6.? || $2 == 4.7.? || $2 == 4_6-branch || $2 == 4_7-branch ]] && echo ppl )
 		isl
 		cloog
 		mingw-w64-download

--- a/scripts/gcc-4_8-branch.sh
+++ b/scripts/gcc-4_8-branch.sh
@@ -50,8 +50,8 @@ PKG_PATCHES=(
 	gcc/gcc-4.7-stdthreads.patch
 	gcc/gcc-4.8-iconv.patch
 	gcc/gcc-4.8-libstdc++export.patch
-	gcc/gcc-4.8-filename-output.patch
-	gcc/gcc-4.8-lambda-ICE.patch
+	#gcc/gcc-4.8-filename-output.patch
+	#gcc/gcc-4.8-lambda-ICE.patch
 	gcc/gcc-4.8.3-libatomic-cygwin.patch
 	gcc/gcc-4.8.2-build-more-gnattools.mingw.patch
 	gcc/gcc-4.8.2-dont-escape-arguments-that-dont-need-it-in-pex-win32.c.patch


### PR DESCRIPTION
I fixed the GCC 4.6 / 4.7 branches to use ppl and removed some patches for the GCC 4.8 branch that are already available upstream. 