### PR TITLE
Some fixes for GCC 5 and binutils

### DIFF
--- a/library/subtargets.sh
+++ b/library/subtargets.sh
@@ -55,7 +55,7 @@ function func_get_subtargets {
 		mpc
 		$( [[ $2 == 4.6.? || $2 == 4.7.? || $2 == 4_6-branch || $2 == 4_7-branch ]] && echo ppl )
 		isl
-		cloog
+		$( [[ $2 == 4* ]] && echo cloog )
 		mingw-w64-download
 		mingw-w64-api
 		mingw-w64-crt

--- a/patches/binutils/fixes-a-problem-recognizing-libraries-created-by-VS.patch
+++ b/patches/binutils/fixes-a-problem-recognizing-libraries-created-by-VS.patch
@@ -1,14 +1,14 @@
 --- a/bfd/coffgen.c
 +++ b/bfd/coffgen.c
 @@ -463,7 +463,10 @@ _bfd_coff_internal_syment_name (bfd *abfd,
-          if (strings == NULL)
-            return NULL;
-        }
+ 	  if (strings == NULL)
+ 	    return NULL;
+ 	}
 -      if (sym->_n._n_n._n_offset >= obj_coff_strings_len (abfd))
 +      /* PR 17910: Only check for string overflow if the length has been set.
 +        Some DLLs, eg those produced by Visual Studio, may not set the length field.  */
 +      if (obj_coff_strings_len (abfd) > 0
 +           && sym->_n._n_n._n_offset >= obj_coff_strings_len (abfd))
-        return NULL;
+ 	return NULL;
        return strings + sym->_n._n_n._n_offset;
      }

--- a/scripts/gcc-5-branch.sh
+++ b/scripts/gcc-5-branch.sh
@@ -48,7 +48,7 @@ PKG_PRIORITY=main
 
 PKG_PATCHES=(
 	gcc/gcc-4.7-stdthreads.patch
-	gcc/gcc-4.8-iconv.patch
+	gcc/gcc-5.1-iconv.patch
 	gcc/gcc-4.8-libstdc++export.patch
 	gcc/gcc-4.8.2-build-more-gnattools.mingw.patch
 	gcc/gcc-4.8.2-fix-for-windows-not-minding-non-existant-parent-dirs.patch


### PR DESCRIPTION
Fixed a patch for GCC-5-branch, binutils and removed CLooG