### PR TITLE
Fixes for GCC/Clang regarding CLooG

### DIFF
--- a/library/subtargets.sh
+++ b/library/subtargets.sh
@@ -55,7 +55,7 @@ function func_get_subtargets {
 		mpc
 		$( [[ $2 == 4.6.? || $2 == 4.7.? || $2 == 4_6-branch || $2 == 4_7-branch ]] && echo ppl )
 		isl
-		$( [[ $2 == 4* ]] && echo cloog )
+		$( [[ $1 == clang || $2 == 4* ]] && echo cloog )
 		mingw-w64-download
 		mingw-w64-api
 		mingw-w64-crt

--- a/scripts/gcc-trunk.sh
+++ b/scripts/gcc-trunk.sh
@@ -86,7 +86,6 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	#
 	--disable-isl-version-check
-	--disable-cloog-version-check
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \
@@ -107,8 +106,7 @@ PKG_CONFIGURE_FLAGS=(
 	#
 	--with-libiconv
 	--with-system-zlib
-	--with-{gmp,mpfr,mpc,isl,cloog}=$PREREQ_DIR/$HOST-$LINK_TYPE_SUFFIX
-	--enable-cloog-backend=isl
+	--with-{gmp,mpfr,mpc,isl}=$PREREQ_DIR/$HOST-$LINK_TYPE_SUFFIX
 	--with-pkgversion="\"$BUILD_ARCHITECTURE-$THREADS_MODEL-$EXCEPTIONS_MODEL${REV_STRING}, $MINGW_W64_PKG_STRING\""
 	--with-bugurl=$BUG_URL
 	#


### PR DESCRIPTION
Removed CLooG for GCC-trunk, Clang still needs it