### PR TITLE
Added option to override the log viewer

### DIFF
--- a/build
+++ b/build
@@ -94,6 +94,7 @@ readonly RUN_ARGS="$@"
 	echo "                                 supported languages. available languages:"
 	echo "                                 ada,c,c++,fortran,objc,obj-c++"
 	echo "    --show-subtargets          - show list of subtargets for selected '--mode'"
+	echo "    --logviewer-command        - use this command for the log viewer"
 	echo "  available Python versions: 2, 3"
 	echo "  available clang versions: 3.4, git"
 	echo "  available gcc versions:"
@@ -270,6 +271,7 @@ while [[ $# > 0 ]]; do
 		--sf-user=*) SF_USER=${1/--sf-user=/} ;;
 		--sf-pass=*) SF_PASSWORD=${1/--sf-pass=/} ;;
 		--debug-upload) DEBUG_UPLOAD=yes ;;
+		--logviewer-command=*) LOGVIEWER=${1/--logviewer-command=/} ;;
 		*)
 			die "bad command line: \"$1\". terminate."
 		;;


### PR DESCRIPTION
Added an option that can override the log-viewer command so that it can be set to a non-GUI program if desired.  This is helpful when scripting builds in a CI environment so that the build doesn't hang because notepad is open.