### PR TITLE
make.sh: disable --enable-case-insensitive-file-system option

### DIFF
--- a/scripts/make.sh
+++ b/scripts/make.sh
@@ -58,7 +58,6 @@ PKG_CONFIGURE_FLAGS=(
 	--host=$HOST
 	--build=$TARGET
 	--prefix=$PREFIX
-	--enable-case-insensitive-file-system
 	--program-prefix=mingw32-
 	--enable-job-server
 	--without-guile


### PR DESCRIPTION
It fixes a problem with GNU Make binaries where they try using 
C++ compiler to compile .c sources by default.

Also referring to the updated GNU Make README.W32 text and 
reply to bug report, this option is not generally recommended:
http://git.savannah.gnu.org/cgit/make.git/commit/?id=83443c706a831c4dd607c8411f7975d98d8ee144
https://savannah.gnu.org/bugs/?46304

The problem is fixed in GNU Make Git repository, therefore make-git.sh 
doesn't have to be updated to work around this bug, though turning off 
this option for consistency might be considered.