### PR TITLE
Update cloog to 0.18.4

### DIFF
--- a/scripts/cloog.sh
+++ b/scripts/cloog.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=0.18.3
+PKG_VERSION=0.18.4
 PKG_NAME=$BUILD_ARCHITECTURE-cloog-${PKG_VERSION}-$LINK_TYPE_SUFFIX
 PKG_DIR_NAME=cloog-${PKG_VERSION}
 PKG_TYPE=.tar.gz


### PR DESCRIPTION
ISL 0.15 has removed some functions, so cloog 0.18.3 is unable to build against it.  Updated cloog to 0.18.4 which builds against isl 0.15 correctly.

This only appears to apply to gcc-4.x and clang.  Based on the scripts, gcc-5.x doesn't use cloog anymore.