### PR TITLE
Restore 4.8 PCH patch

### DIFF
--- a/patches/gcc/gcc-4.8-fix-PCH.patch
+++ b/patches/gcc/gcc-4.8-fix-PCH.patch
@@ -1,0 +1,23 @@
+Index: gcc/config/i386/host-mingw32.c
+===================================================================
+--- gcc/config/i386/host-mingw32.c	(revision 225106)
++++ gcc/config/i386/host-mingw32.c	(working copy)
+@@ -42,9 +42,6 @@
+ 
+ static inline void w32_error(const char*, const char*, int, const char*);
+ 
+-/* FIXME: Is this big enough?  */
+-static const size_t pch_VA_max_size  = 128 * 1024 * 1024;
+-
+ /* Granularity for reserving address space.  */
+ static size_t va_granularity = 0x10000;
+ 
+@@ -148,7 +145,7 @@
+ 
+   /* Offset must be also be a multiple of allocation granularity for
+      this to work.  We can't change the offset. */ 
+-  if ((offset & (va_granularity - 1)) != 0 || size > pch_VA_max_size)
++  if ((offset & (va_granularity - 1)) != 0)
+     return -1;
+ 
+ 


### PR DESCRIPTION
This apparently got renamed when one of the GCC 5 versions was being added and causes build breakage since. I dug up the old version of the patch and re-added it to the tree. Don't see any difference in the build behavior though (all tests pass either way) so I don't know what this patch is for exactly.