### PR TITLE
Fix ISL version for older GCC

### DIFF
--- a/scripts/gcc-4.8.4.sh
+++ b/scripts/gcc-4.8.4.sh
@@ -94,8 +94,6 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
-	--disable-isl-version-check
-	--disable-cloog-version-check
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-4.8.5.sh
+++ b/scripts/gcc-4.8.5.sh
@@ -57,7 +57,6 @@ PKG_PATCHES=(
 	gcc/gcc-4.8.2-fix-for-windows-not-minding-non-existant-parent-dirs.patch
 	gcc/gcc-4.8.2-windows-lrealpath-no-force-lowercase-nor-backslash.patch
 	gcc/lto-plugin-use-static-libgcc.patch
-	gcc/gcc-4.8-fix-PCH.patch
 )
 
 #
@@ -93,8 +92,6 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
-	--disable-isl-version-check
-	--disable-cloog-version-check
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-4.9.0.sh
+++ b/scripts/gcc-4.9.0.sh
@@ -98,8 +98,6 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
-	--disable-isl-version-check
-	--disable-cloog-version-check
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-4.9.1.sh
+++ b/scripts/gcc-4.9.1.sh
@@ -96,8 +96,6 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
-	--disable-isl-version-check
-	--disable-cloog-version-check
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-4.9.2.sh
+++ b/scripts/gcc-4.9.2.sh
@@ -95,8 +95,6 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
-	--disable-isl-version-check
-	--disable-cloog-version-check
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-4.9.3.sh
+++ b/scripts/gcc-4.9.3.sh
@@ -94,8 +94,6 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
-	--disable-isl-version-check
-	--disable-cloog-version-check
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-4_8-branch.sh
+++ b/scripts/gcc-4_8-branch.sh
@@ -92,8 +92,6 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
-	--disable-isl-version-check
-	--disable-cloog-version-check
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-4_9-branch.sh
+++ b/scripts/gcc-4_9-branch.sh
@@ -91,8 +91,6 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
-	--disable-isl-version-check
-	--disable-cloog-version-check
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-5.1.0.sh
+++ b/scripts/gcc-5.1.0.sh
@@ -97,7 +97,6 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
-	--disable-isl-version-check
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-5.2.0.sh
+++ b/scripts/gcc-5.2.0.sh
@@ -98,7 +98,6 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
-	--disable-isl-version-check
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-5.3.0.sh
+++ b/scripts/gcc-5.3.0.sh
@@ -98,7 +98,6 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
-	--disable-isl-version-check
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/isl.sh
+++ b/scripts/isl.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=0.15
+PKG_VERSION=$( [[ $GCC_NAME == gcc-4* ]] && { echo 0.14.1; } || { echo 0.15; } )
 PKG_NAME=$BUILD_ARCHITECTURE-isl-${PKG_VERSION}-$LINK_TYPE_SUFFIX
 PKG_DIR_NAME=isl-${PKG_VERSION}
 PKG_TYPE=.tar.xz


### PR DESCRIPTION
GCC 4.x doesn't work properly with ISL 0.15, so use ISL 0.14.1 for those versions.

Also re-enabled the ISL and Cloog version checks, they do work properly so there is no reason to disable them.