### PR TITLE
Error output and logviewer improvements

### DIFF
--- a/build
+++ b/build
@@ -95,6 +95,7 @@ readonly RUN_ARGS="$@"
 	echo "                                 ada,c,c++,fortran,objc,obj-c++"
 	echo "    --show-subtargets          - show list of subtargets for selected '--mode'"
 	echo "    --logviewer-command        - use this command for the log viewer"
+	echo "    --wait-for-logviewer       - wait until after logviewer completes, e.g. for echo"
 	echo "  available Python versions: 2, 3"
 	echo "  available clang versions: 3.4, git"
 	echo "  available gcc versions:"
@@ -275,6 +276,7 @@ while [[ $# > 0 ]]; do
 		--sf-pass=*) SF_PASSWORD=${1/--sf-pass=/} ;;
 		--debug-upload) DEBUG_UPLOAD=yes ;;
 		--logviewer-command=*) LOGVIEWER=${1/--logviewer-command=/} ;;
+		--wait-for-logviewer) LOGVIEWER_WAIT=yes ;;
 		*)
 			die "bad command line: \"$1\". terminate."
 		;;

--- a/library/config.sh
+++ b/library/config.sh
@@ -181,6 +181,7 @@ echo "done"
 # **************************************************************************
 
 LOGVIEWER=
+LOGVIEWER_WAIT=no
 
 func_find_logviewer \
 	LOGVIEWERS[@] \

--- a/library/functions.sh
+++ b/library/functions.sh
@@ -102,7 +102,13 @@ function die {
 
 function func_show_log {
 	# $1 - log file
-	[[ $SHOW_LOG_ON_ERROR == yes ]] && { $LOGVIEWER $1 & }
+	[[ $SHOW_LOG_ON_ERROR == yes ]] && {
+		[[ $LOGVIEWER_WAIT == yes ]] && {
+			$LOGVIEWER $1
+		} || {
+			$LOGVIEWER $1 &
+		}
+	}
 }
 
 # **************************************************************************

--- a/library/functions.sh
+++ b/library/functions.sh
@@ -95,13 +95,14 @@ function die {
 	# $2 - exit code
 	local _retcode=1
 	[[ -n $2 ]] && _retcode=$2
-	echo $1
+	echo
+	>&2 echo $1
 	exit $_retcode
 }
 
 function func_show_log {
 	# $1 - log file
-	[[ $SHOW_LOG_ON_ERROR == yes ]] && $LOGVIEWER $1 &
+	[[ $SHOW_LOG_ON_ERROR == yes ]] && { $LOGVIEWER $1 & }
 }
 
 # **************************************************************************


### PR DESCRIPTION
I've modified the logic to output the terminating errors in the `die` function to standard error instead of standard output.  This enables better behavior on a build server since it can recognize the standard error output and know that it's something to highlight.

I've also added the ability to indicate that the logviewer should be a blocking command.  When using something like `cat` to print out the logs (mainly for on a build server, no other tools work properly there) the build scripts need to wait until cat exits before stopping.  This is most noticeable when using `cat` from the command line, if the command doesn't block the prompt will appear before all of the error log file will be written out.

Fairly basic changes that don't really affect the actual build process at all.