### PR TITLE
gcc 8.1 & libs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,11 @@ At the moment, successfully building the following versions:
   gcc-6.1.0
   gcc-6.2.0
   gcc-6.3.0
+  gcc-6.4.0
   gcc-7.1.0
   gcc-7.2.0
   gcc-7.3.0
+  gcc-8.1.0
   gcc-4_6-branch (currently 4.6.5 prerelease)
   gcc-4_7-branch (currently 4.7.5 prerelease)
   gcc-4_8-branch (currently 4.8.6 prerelease)
@@ -114,7 +116,8 @@ At the moment, successfully building the following versions:
   gcc-5-branch (currently 5.6.0 prerelease)
   gcc-6-branch (currently 6.5.0 prerelease)
   gcc-7-branch (currently 7.4.0 prerelease)
-  gcc-trunk (currently 8.0.0 snapshot)
+  gcc-8-branch (currently 8.2.0 prerelease)
+  gcc-trunk (currently 9.0.0 snapshot)
 ```
 
 Builds also contains patches for building Python 2.7.9 and 3.4.3 versions for support gdb pretty printers.

--- a/build
+++ b/build
@@ -139,7 +139,9 @@ readonly RUN_ARGS="$@"
 	echo "    gcc-7.2.0 (7.2.0 release)"
 	echo "    gcc-7.3.0 (7.3.0 release)"
 	echo "    gcc-7-branch (currently 7.4.0-prerelease)"
-	echo "    gcc-trunk (currently 8-snapshot)"
+	echo "    gcc-8.1.0 (8.1.0 release)"
+	echo "    gcc-8-branch (currently 8.2.0-prerelease)"
+	echo "    gcc-trunk (currently 9-snapshot)"
 
 	exit 0
 }

--- a/library/functions.sh
+++ b/library/functions.sh
@@ -931,8 +931,9 @@ function func_map_gcc_name_to_gcc_version {
 		gcc-4_9-branch)	echo "4.9.5" ;;
 		gcc-5-branch)	echo "5.6.0" ;;
 		gcc-6-branch)	echo "6.5.0" ;;
-		gcc-7-branch)	echo "7.3.0" ;;
-		gcc-trunk)		echo "8.0.0" ;;
+		gcc-7-branch)	echo "7.4.0" ;;
+		gcc-8-branch)	echo "8.2.0" ;;
+		gcc-trunk)		echo "9.0.0" ;;
 		*) die "gcc name error: $1. terminate." ;;
 	esac
 }

--- a/patches/mingw-w64/incorrect_cast_fix.patch
+++ b/patches/mingw-w64/incorrect_cast_fix.patch
@@ -1,0 +1,15 @@
+diff --git a/mingw-w64-tools/gendef/src/fsredir.c b/mingw-w64-tools/gendef/src/fsredir.c
+index 36afd838..ee924feb 100644
+--- a/mingw-w64-tools/gendef/src/fsredir.c
++++ b/mingw-w64-tools/gendef/src/fsredir.c
+@@ -25,8 +25,8 @@
+ 
+ static PVOID revert; /*revert pointer*/
+ static HMODULE kernel32handle;
+-typedef WINBOOL (__stdcall (*redirector))(PVOID *);
+-typedef WINBOOL (__stdcall (*revertor))(PVOID);
++typedef size_t (__stdcall (*redirector))(PVOID *);
++typedef size_t (__stdcall (*revertor))(PVOID);
+ static redirector redirectorfunction; /*Wow64DisableWow64FsRedirection*/
+ static revertor revertorfunction;     /*Wow64RevertWow64FsRedirection*/
+

--- a/scripts/gcc-8-branch.sh
+++ b/scripts/gcc-8-branch.sh
@@ -35,11 +35,12 @@
 
 # **************************************************************************
 
-PKG_NAME=gcc-trunk
-PKG_DIR_NAME=gcc-trunk
+PKG_VERSION=8-branch
+PKG_NAME=gcc-${PKG_VERSION}
+PKG_DIR_NAME=gcc-${PKG_VERSION}
 PKG_TYPE=svn
 PKG_URLS=(
-	"svn://gcc.gnu.org/svn/gcc/trunk|repo:$PKG_TYPE|module:$PKG_NAME"
+	"svn://gcc.gnu.org/svn/gcc/branches/${PKG_NAME}|repo:$PKG_TYPE"
 )
 
 PKG_PRIORITY=main

--- a/scripts/gcc-8.1.0.sh
+++ b/scripts/gcc-8.1.0.sh
@@ -35,11 +35,12 @@
 
 # **************************************************************************
 
-PKG_NAME=gcc-trunk
-PKG_DIR_NAME=gcc-trunk
-PKG_TYPE=svn
+PKG_VERSION=8.1.0
+PKG_NAME=gcc-${PKG_VERSION}
+PKG_DIR_NAME=gcc-${PKG_VERSION}
+PKG_TYPE=.tar.xz
 PKG_URLS=(
-	"svn://gcc.gnu.org/svn/gcc/trunk|repo:$PKG_TYPE|module:$PKG_NAME"
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}${PKG_TYPE}"
 )
 
 PKG_PRIORITY=main

--- a/scripts/isl.sh
+++ b/scripts/isl.sh
@@ -38,11 +38,11 @@
 if [[ ${BUILD_VERSION:0:1} == 4 && ${BUILD_VERSION:2:1} -le 8 ]] || [[ ${BUILD_VERSION:0:1} == 4 && ${BUILD_VERSION:2:1} == 9 && ${BUILD_VERSION:4:1} -le 2 ]]; then
    PKG_VERSION=0.12.2
    PKG_TYPE=.tar.lzma
-elif [[ $GCC_NAME == gcc-4* ]] || [[ ${BUILD_VERSION:0:1} == 5 && ${BUILD_VERSION:2:1} -le 2 ]]; then
+elif [[ ${BUILD_VERSION:0:1} == 4 ]] || [[ ${BUILD_VERSION:0:1} == 5 && ${BUILD_VERSION:2:1} -le 2 ]]; then
    PKG_VERSION=0.14.1
    PKG_TYPE=.tar.xz
 else
-   PKG_VERSION=0.18
+   PKG_VERSION=0.19
    PKG_TYPE=.tar.xz
 fi
 PKG_NAME=$BUILD_ARCHITECTURE-isl-${PKG_VERSION}-$LINK_TYPE_SUFFIX
@@ -61,7 +61,7 @@ PKG_PATCHES=(
 
 #
 
-if [[ ${PKG_VERSION} == 0.18 ]]; then
+if [[ ${PKG_VERSION} == 0.18 || ${PKG_VERSION} == 0.19 ]]; then
 	PKG_EXECUTE_AFTER_PATCH=(
 		"aclocal"
 		"automake"

--- a/scripts/mingw-w64-tools-gendef.sh
+++ b/scripts/mingw-w64-tools-gendef.sh
@@ -42,7 +42,9 @@ PKG_PRIORITY=extra
 
 #
 
-PKG_PATCHES=()
+PKG_PATCHES=(
+	mingw-w64/incorrect_cast_fix.patch
+)
 
 #
 

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=1.0.2n
+PKG_VERSION=1.0.2o
 PKG_NAME=openssl-${PKG_VERSION}
 PKG_DIR_NAME=openssl-${PKG_VERSION}
 PKG_TYPE=.tar.gz

--- a/scripts/sqlite.sh
+++ b/scripts/sqlite.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=3220000
+PKG_VERSION=3230100
 PKG_NAME=sqlite-${PKG_VERSION}
 PKG_DIR_NAME=sqlite-autoconf-${PKG_VERSION}
 PKG_TYPE=.tar.gz

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -119,4 +119,4 @@ PKG_TESTS["lasterror_test2"]=lasterror_test2_list[@]
 PKG_TESTS["time_test"]=time_test_list[@]
 [[ $THREADS_MODEL == posix ]] && { PKG_TESTS["sleep_test"]=sleep_test_list[@]; }
 [[ ${BUILD_VERSION:0:1} -ge 6 ]] && { PKG_TESTS["random_device"]=random_device_list[@]; }
-[[ ${BUILD_VERSION:0:1} -ge 7 ]] && { PKG_TESTS["filesystem"]=filesystem_list[@]; }
+[[ ${BUILD_VERSION:0:1} == 7 ]] && { PKG_TESTS["filesystem"]=filesystem_list[@]; }

--- a/scripts/xz-utils.sh
+++ b/scripts/xz-utils.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=5.2.3
+PKG_VERSION=5.2.4
 PKG_NAME=xz-${PKG_VERSION}
 PKG_DIR_NAME=xz-${PKG_VERSION}
 PKG_TYPE=.tar.xz


### PR DESCRIPTION
- Added gcc 8.1.0 (No experimental filesystem support. filesystem.patch must be adapted(I tried to do this, but didn't managed to fix all errors. ))
- Added gcc-8-branch (currently 8.2.0 prerelease)
- Disabled filesystem test for new gcc versions
- Updated isl, openssl, sqlite, xz
- Fixed cast between incompatible function types(more info below)

mingw-w64-tools-gendef build fails with gcc 8.1 due to new cast check that deprecates undefined behavior(in this case cast from long long int(64 bit type) to int(32 bit type) ) :
```
../../../src/mingw-w64/mingw-w64-tools/gendef/src/fsredir.c: In function 'doredirect':
../../../src/mingw-w64/mingw-w64-tools/gendef/src/fsredir.c:44:26: error: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'WINBOOL (*)(void **)' {aka 'int (*)(void **)'} [-Werror=cast-function-type]
     redirectorfunction = (redirector)GetProcAddress(kernel32handle, "Wow64DisableWow64FsRedirection");
                          ^
../../../src/mingw-w64/mingw-w64-tools/gendef/src/fsredir.c:45:24: error: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'WINBOOL (*)(void *)' {aka 'int (*)(void *)'} [-Werror=cast-function-type]
     revertorfunction = (revertor)GetProcAddress(kernel32handle, "Wow64RevertWow64FsRedirection");
                        ^
cc1.exe: all warnings being treated as errors
make[1]: *** [Makefile:485: src/gendef-fsredir.o] Error 1
```
If i correctly understand code, looks like this bug can be fixed by replacing WINBOOL with size_t.