### PR TITLE
Fixes & updates

### DIFF
--- a/patches/libgnurx/mingw32-libgnurx-configure.ac
+++ b/patches/libgnurx/mingw32-libgnurx-configure.ac
@@ -1,7 +1,7 @@
 # configure.ac  -*- Autoconf -*-
 # Process this file with autoconf, to generate a configure script.
 
-AC_INIT(libgnurx, 2.5.1)
+AC_INIT(libgnurx, 2.7.0)
 AM_INIT_AUTOMAKE
 AC_PROG_INSTALL
 AC_LIBTOOL_DLOPEN

--- a/scripts/libgnurx.sh
+++ b/scripts/libgnurx.sh
@@ -35,12 +35,13 @@
 
 # **************************************************************************
 
-PKG_VERSION=2.5.1
+PKG_VERSION=2.7.0
 PKG_NAME=libgnurx-${PKG_VERSION}
-PKG_DIR_NAME=mingw-libgnurx-${PKG_VERSION}
+PKG_DIR_NAME=libgnurx-libgnurx-${PKG_VERSION}
 PKG_TYPE=.tar.gz
 PKG_URLS=(
-	"https://sourceforge.net/projects/mingw/files/Other/UserContributed/regex/mingw-regex-${PKG_VERSION}/mingw-libgnurx-${PKG_VERSION}-src.tar.gz"
+	# "https://sourceforge.net/projects/mingw/files/Other/UserContributed/regex/mingw-regex-${PKG_VERSION}/mingw-libgnurx-${PKG_VERSION}-src.tar.gz"
+	"https://github.com/Furniel/libgnurx/archive/libgnurx-${PKG_VERSION}${PKG_TYPE}"
 )
 
 PKG_PRIORITY=extra
@@ -54,8 +55,8 @@ PKG_PATCHES=(
 #
 
 PKG_EXECUTE_AFTER_PATCH=(
-	"cp -rf $PATCHES_DIR/libgnurx/mingw32-libgnurx-configure.ac $SRCS_DIR/mingw-libgnurx-2.5.1/configure.ac"
-	"cp -rf $PATCHES_DIR/libgnurx/mingw32-libgnurx-Makefile.am $SRCS_DIR/mingw-libgnurx-2.5.1/Makefile.am"
+	"cp -rf $PATCHES_DIR/libgnurx/mingw32-libgnurx-configure.ac $SRCS_DIR/${PKG_DIR_NAME}/configure.ac"
+	"cp -rf $PATCHES_DIR/libgnurx/mingw32-libgnurx-Makefile.am $SRCS_DIR/${PKG_DIR_NAME}/Makefile.am"
 	"touch AUTHORS"
 	"touch NEWS"
 	"libtoolize --copy"

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -119,4 +119,4 @@ PKG_TESTS["lasterror_test2"]=lasterror_test2_list[@]
 PKG_TESTS["time_test"]=time_test_list[@]
 [[ $THREADS_MODEL == posix ]] && { PKG_TESTS["sleep_test"]=sleep_test_list[@]; }
 [[ ${BUILD_VERSION:0:1} -ge 6 ]] && { PKG_TESTS["random_device"]=random_device_list[@]; }
-[[ ${BUILD_VERSION:0:1} == 7 ]] && { PKG_TESTS["filesystem"]=filesystem_list[@]; }
+[[ ${BUILD_VERSION:0:1} -ge 7 ]] && { PKG_TESTS["filesystem"]=filesystem_list[@]; }


### PR DESCRIPTION
- Reenabled filesystem test for gcc 8+
- Updated libgnurx to 2.7.0  (  original 2.5.1 version was based on glibc 2.5 and was updated in 2007, i found TimothyGus fork that was updated in 2015 and contains glibc changes up to 2.22, forked it and imported all glibc changes up to 2.27 ). This update should fix all bugs that were found in posix regex realisation since 2007.
links: 
Original fork: https://github.com/TimothyGu/libgnurx
My fork: https://github.com/Furniel/libgnurx
