### PR TITLE
gcc-7-branch-diagnostic-color.c.patch: Backport two patches from master.

### DIFF
--- a/patches/gcc/gcc-7-branch-diagnostic-color.c.patch
+++ b/patches/gcc/gcc-7-branch-diagnostic-color.c.patch
@@ -1,13 +1,13 @@
-From 597cbbbf789ecef0af62686d02a8e342cda8371e Mon Sep 17 00:00:00 2001
+From 0c2437d3bbedf82a1ad0dbfd5c8045b3b8c756b8 Mon Sep 17 00:00:00 2001
 From: Liu Hao <lh_mouse@126.com>
 Date: Wed, 6 Sep 2017 17:28:12 +0800
 Subject: [PATCH] This patch enables a native GCC to color diagnostic messages
  sent over Windows consoles.
 
 ---
- gcc/diagnostic-color.c |  28 ++-
- gcc/pretty-print.c     | 606 +++++++++++++++++++++++++++++++++++++++++++++++++
- 2 files changed, 624 insertions(+), 10 deletions(-)
+ gcc/diagnostic-color.c |  28 +-
+ gcc/pretty-print.c     | 615 +++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 633 insertions(+), 10 deletions(-)
 
 diff --git a/gcc/diagnostic-color.c b/gcc/diagnostic-color.c
 index 8353fe016b7..c002331a31f 100644
@@ -68,10 +68,10 @@ index 8353fe016b7..c002331a31f 100644
  }
 -#endif
 diff --git a/gcc/pretty-print.c b/gcc/pretty-print.c
-index bcb1a70ac03..91685484a39 100644
+index bcb1a70ac03..c42da6b1669 100644
 --- a/gcc/pretty-print.c
 +++ b/gcc/pretty-print.c
-@@ -30,6 +30,608 @@ along with GCC; see the file COPYING3.  If not see
+@@ -30,6 +30,617 @@ along with GCC; see the file COPYING3.  If not see
  #include <iconv.h>
  #endif
  
@@ -627,6 +627,16 @@ index bcb1a70ac03..91685484a39 100644
 +	{
 +	  attrib_add |= sb.wAttributes & ~attrib_rm;
 +	}
++      if (attrib_add & COMMON_LVB_REVERSE_VIDEO)
++	{
++	  /* COMMON_LVB_REVERSE_VIDEO is only effective for DBCS.
++	   * Swap foreground and background colors by hand.
++	   */
++	  attrib_add = (attrib_add & 0xFF00)
++			| ((attrib_add & 0x00F0) >> 4)
++			| ((attrib_add & 0x000F) << 4);
++	  attrib_add &= ~COMMON_LVB_REVERSE_VIDEO;
++	}
 +      SetConsoleTextAttribute (h, attrib_add);
 +      break;
 +    }
@@ -671,7 +681,6 @@ index bcb1a70ac03..91685484a39 100644
 +    /* If it is not a console, write everything as-is. */
 +    write_all (h, read, strlen (read));
 +
-+  _close ((intptr_t)h);
 +  return 1;
 +}
 +
@@ -680,7 +689,7 @@ index bcb1a70ac03..91685484a39 100644
  static void pp_quoted_string (pretty_printer *, const char *, size_t = -1);
  
  /* Overwrite the given location/range within this text_info's rich_location.
-@@ -140,7 +742,11 @@ void
+@@ -140,7 +751,11 @@ void
  pp_write_text_to_stream (pretty_printer *pp)
  {
    const char *text = pp_formatted_text (pp);
@@ -693,5 +702,5 @@ index bcb1a70ac03..91685484a39 100644
  }
  
 -- 
-2.13.3
+2.18.0
 


### PR DESCRIPTION
Reference: https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=263530
Reference: https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=263531
Signed-off-by: Liu Hao <lh_mouse@126.com>