### PR TITLE
Updates

### DIFF
--- a/build
+++ b/build
@@ -230,7 +230,7 @@ while [[ $# > 0 ]]; do
 			BASE_LDFLAGS="$BASE_LDFLAGS -flto -fuse-linker-plugin"
 		;;
 		--no-multilib) USE_MULTILIB=no ;;
-		--no-extras) BUILD_EXTRAS=no ;;
+		--no-extras) [[ $BUILD_MODE != python ]] && { BUILD_EXTRAS=no; };;
 		--no-strip) STRIP_ON_INSTALL=no ;;
 		--static-gcc)
 			BOOTSTRAPING=yes

--- a/patches/gcc/gcc-8.2.0-Backport-patches-for-std-filesystem-from-master.patch
+++ b/patches/gcc/gcc-8.2.0-Backport-patches-for-std-filesystem-from-master.patch
@@ -1,4 +1,4 @@
-From 953d61a7250a144603df548e1d80651ea9190f12 Mon Sep 17 00:00:00 2001
+From ff9550c0761d269ac0b7a7423a15befc37946cac Mon Sep 17 00:00:00 2001
 From: Liu Hao <lh_mouse@126.com>
 Date: Sat, 23 Jun 2018 17:02:02 +0800
 Subject: [PATCH] Backport patches for std::filesystem from master.
@@ -20,7 +20,6 @@ Signed-off-by: Liu Hao <lh_mouse@126.com>
  libstdc++-v3/configure                        |  35 +++
  libstdc++-v3/configure.ac                     |   2 +
  libstdc++-v3/crossconfig.m4                   |   1 +
- libstdc++-v3/include/bits/fs_dir.h            |   5 +-
  libstdc++-v3/include/bits/fs_path.h           | 251 +++++++++--------
  libstdc++-v3/include/bits/fstream.tcc         |  36 +++
  .../include/experimental/bits/fs_path.h       |  74 ++---
@@ -32,11 +31,11 @@ Signed-off-by: Liu Hao <lh_mouse@126.com>
  libstdc++-v3/src/filesystem/path.cc           |  24 +-
  libstdc++-v3/src/filesystem/std-dir.cc        |   5 +-
  libstdc++-v3/src/filesystem/std-ops.cc        | 260 ++++++++++++------
- libstdc++-v3/src/filesystem/std-path.cc       | 122 +++++---
- 19 files changed, 933 insertions(+), 371 deletions(-)
+ libstdc++-v3/src/filesystem/std-path.cc       | 105 +++++--
+ 18 files changed, 929 insertions(+), 353 deletions(-)
 
 diff --git a/libstdc++-v3/config.h.in b/libstdc++-v3/config.h.in
-index 765cedc6edf..3fb685ce9aa 100644
+index 5a0f0678439..1fc10b511fb 100644
 --- a/libstdc++-v3/config.h.in
 +++ b/libstdc++-v3/config.h.in
 @@ -264,6 +264,9 @@
@@ -140,7 +139,7 @@ index 58f24f670f6..3c857272c57 100644
        sys_open(__c_file* __file, ios_base::openmode);
  
 diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
-index 5535bfa2b5a..b9883d413f6 100755
+index fbc9daeb195..3dd63c9631d 100755
 --- a/libstdc++-v3/configure
 +++ b/libstdc++-v3/configure
 @@ -28127,6 +28127,17 @@ eval as_val=\$$as_ac_var
@@ -231,22 +230,6 @@ index cb6e3afff3d..669d87f7602 100644
      ;;
    *-netbsd*)
      SECTION_FLAGS='-ffunction-sections -fdata-sections'
-diff --git a/libstdc++-v3/include/bits/fs_dir.h b/libstdc++-v3/include/bits/fs_dir.h
-index c8c1e5e5bef..6b332e171cf 100644
---- a/libstdc++-v3/include/bits/fs_dir.h
-+++ b/libstdc++-v3/include/bits/fs_dir.h
-@@ -313,10 +313,7 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
-     _M_file_type(error_code& __ec) const noexcept
-     {
-       if (_M_type != file_type::none && _M_type != file_type::symlink)
--	{
--	  __ec.clear();
--	  return _M_type;
--	}
-+	return _M_type;
-       return status(__ec).type();
-     }
- 
 diff --git a/libstdc++-v3/include/bits/fs_path.h b/libstdc++-v3/include/bits/fs_path.h
 index 51af2891647..e3938d06d59 100644
 --- a/libstdc++-v3/include/bits/fs_path.h
@@ -2397,7 +2380,7 @@ index 74868cd48e6..e266fa6d3f8 100644
    if (ec)
      result.clear();
 diff --git a/libstdc++-v3/src/filesystem/std-path.cc b/libstdc++-v3/src/filesystem/std-path.cc
-index d5016e06138..f6c0b8bb0f6 100644
+index 6f594cec1d5..f6c0b8bb0f6 100644
 --- a/libstdc++-v3/src/filesystem/std-path.cc
 +++ b/libstdc++-v3/src/filesystem/std-path.cc
 @@ -38,6 +38,66 @@ fs::filesystem_error::~filesystem_error() = default;
@@ -2535,43 +2518,12 @@ index d5016e06138..f6c0b8bb0f6 100644
      {
  #ifdef _GLIBCXX_FILESYSTEM_IS_WINDOWS
        // Replace each slash character in the root-name
--      if (p._M_type == _Type::_Root_name || p._M_type == _Type::_Root_dir)
+-      if (p.is_root_name())
 +      if (p._M_type == _Type::_Root_name)
  	{
  	  string_type s = p.native();
  	  std::replace(s.begin(), s.end(), L'/', L'\\');
-@@ -398,8 +458,7 @@ path::lexically_normal() const
- 	    }
- 	  else if (!ret.has_relative_path())
- 	    {
--	      // remove a dot-dot filename immediately after root-directory
--	      if (!ret.has_root_directory())
-+	      if (!ret.is_absolute())
- 		ret /= p;
- 	    }
- 	  else
-@@ -412,18 +471,8 @@ path::lexically_normal() const
- 		{
- 		  // Remove the filename before the trailing slash
- 		  // (equiv. to ret = ret.parent_path().remove_filename())
--
--		  if (elem == ret.begin())
--		    ret.clear();
--		  else
--		    {
--		      ret._M_pathname.erase(elem._M_cur->_M_pos);
--		      // Do we still have a trailing slash?
--		      if (std::prev(elem)->_M_type == _Type::_Filename)
--			ret._M_cmpts.erase(elem._M_cur);
--		      else
--			ret._M_cmpts.erase(elem._M_cur, ret._M_cmpts.end());
--		    }
-+		  ret._M_pathname.erase(elem._M_cur->_M_pos);
-+		  ret._M_cmpts.erase(elem._M_cur, ret._M_cmpts.end());
- 		}
- 	      else // ???
- 		ret /= p;
-@@ -498,7 +547,7 @@ path::lexically_proximate(const path& base) const
+@@ -487,7 +547,7 @@ path::lexically_proximate(const path& base) const
  std::pair<const path::string_type*, std::size_t>
  path::_M_find_extension() const
  {
@@ -2580,7 +2532,7 @@ index d5016e06138..f6c0b8bb0f6 100644
  
    if (_M_type == _Type::_Filename)
      s = &_M_pathname;
-@@ -513,9 +562,9 @@ path::_M_find_extension() const
+@@ -502,9 +562,9 @@ path::_M_find_extension() const
      {
        if (auto sz = s->size())
  	{
@@ -2592,7 +2544,7 @@ index d5016e06138..f6c0b8bb0f6 100644
  	  return { s, pos ? pos : string_type::npos };
  	}
      }
-@@ -525,11 +574,13 @@ path::_M_find_extension() const
+@@ -514,11 +574,13 @@ path::_M_find_extension() const
  void
  path::_M_split_cmpts()
  {
@@ -2609,7 +2561,7 @@ index d5016e06138..f6c0b8bb0f6 100644
  
    size_t pos = 0;
    const size_t len = _M_pathname.size();
-@@ -604,8 +655,7 @@ path::_M_split_cmpts()
+@@ -593,8 +655,7 @@ path::_M_split_cmpts()
        // An empty element, if trailing non-root directory-separator present.
        if (_M_cmpts.back()._M_type == _Type::_Filename)
  	{
@@ -2619,7 +2571,7 @@ index d5016e06138..f6c0b8bb0f6 100644
  	  _M_cmpts.emplace_back(string_type(), _Type::_Filename, pos);
  	}
      }
-@@ -715,8 +765,8 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
+@@ -704,8 +765,8 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
  
    std::string filesystem_error::_M_gen_what()
    {
@@ -2631,5 +2583,5 @@ index d5016e06138..f6c0b8bb0f6 100644
  
  _GLIBCXX_END_NAMESPACE_CXX11
 -- 
-2.18.0
+2.17.1
 

--- a/scripts/expat.sh
+++ b/scripts/expat.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=2.2.5
+PKG_VERSION=2.2.6
 PKG_NAME=expat-${PKG_VERSION}
 PKG_DIR_NAME=expat-${PKG_VERSION}
 PKG_TYPE=.tar.bz2

--- a/scripts/gcc-8.2.0.sh
+++ b/scripts/gcc-8.2.0.sh
@@ -60,7 +60,7 @@ PKG_PATCHES=(
 	gcc/gcc-5.1.0-fix-libatomic-building-for-threads=win32.patch
 	gcc/gcc-6-ktietz-libgomp.patch
 	gcc/gcc-libgomp-ftime64.patch
-	gcc/gcc-8-branch-Backport-patches-for-std-filesystem-from-master.patch
+	gcc/gcc-8.2.0-Backport-patches-for-std-filesystem-from-master.patch
 	gcc/gcc-8-isl-0.20-support.patch
 )
 

--- a/scripts/gdb.sh
+++ b/scripts/gdb.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=$( [[ $GCC_NAME == gcc-4.6* || $GCC_NAME == gcc-4.7* || $GCC_NAME == gcc-4.8.0 ]] && { echo 7.12; } || { echo 8.1.1; } )
+PKG_VERSION=$( [[ $GCC_NAME == gcc-4.6* || $GCC_NAME == gcc-4.7* || $GCC_NAME == gcc-4.8.0 ]] && { echo 7.12; } || { echo 8.2; } )
 PKG_NAME=gdb-${PKG_VERSION}
 PKG_DIR_NAME=gdb-${PKG_VERSION}
 PKG_TYPE=.tar.xz

--- a/scripts/gdbm.sh
+++ b/scripts/gdbm.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=1.17
+PKG_VERSION=1.18
 PKG_NAME=gdbm-${PKG_VERSION}
 PKG_DIR_NAME=gdbm-${PKG_VERSION}
 PKG_TYPE=.tar.gz

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=1.0.2o
+PKG_VERSION=1.0.2p
 PKG_NAME=openssl-${PKG_VERSION}
 PKG_DIR_NAME=openssl-${PKG_VERSION}
 PKG_TYPE=.tar.gz


### PR DESCRIPTION
- gdbm 1.18
- openssl 1.0.2p
- gdb 8.2
- expat 2.2.6
- fixed gcc-8-branch builds(updated filesystem patch)
- fixed python can't be build with --no-extras switch