### PR TITLE
Allow specifying MSVCRT version

### DIFF
--- a/build
+++ b/build
@@ -70,6 +70,8 @@ readonly RUN_ARGS="$@"
 	echo "    --rt-version=<v3|v4|v5|v6|trunk|v3.3.0|v4.0.6|v5.0.4|v6.0.0> - specifies mingw-w64 runtime version to build"
 	echo "                                 v3, v4, v5, v6, trunk specifies specific branches in the git repo"
 	echo "                                 v3.3.0, v4.0.6, v5.0.4, v6.0.0 is a specific release versions, uses the tarball"
+	echo "    --with-default-msvcrt=     - specifies msvc version the toolchain will target"
+	echo "                                 <msvcrt|msvcr80|msvcr90|msvcr100|msvcr110|msvcr120|ucrt>"
 	echo "    --rev=N                    - specifies number of the build revision"
 	echo "    --threads=<model>          - specifies the threads model for GCC/libstdc++"
 	echo "                                 available: win32, posix"
@@ -296,6 +298,9 @@ while [[ $# > 0 ]]; do
 					die "Unsupported runtime version $RUNTIME_VERSION."
 				;;
 			esac
+		;;
+		--with-default-msvcrt=*)
+			MSVCRT_VERSION=${1/--with-default-msvcrt=/}
 		;;
 		--threads=*)
 			THREADS_MODEL=${1/--threads=/}

--- a/scripts/mingw-w64-api.sh
+++ b/scripts/mingw-w64-api.sh
@@ -66,6 +66,9 @@ PKG_CONFIGURE_FLAGS=(
 	#
 	--enable-sdk=all
 	--enable-secure-api
+	$( [[ -n "$MSVCRT_VERSION" ]] \
+		&& echo "--with-default-msvcrt=$MSVCRT_VERSION"
+	)
 	#
 	CFLAGS="\"$COMMON_CFLAGS\""
 	CXXFLAGS="\"$COMMON_CXXFLAGS\""

--- a/scripts/mingw-w64-crt.sh
+++ b/scripts/mingw-w64-crt.sh
@@ -74,6 +74,9 @@ PKG_CONFIGURE_FLAGS=(
 	#
 	$LIBCONF
 	--enable-wildcard
+	$( [[ -n "$MSVCRT_VERSION" ]] \
+		&& echo "--with-default-msvcrt=$MSVCRT_VERSION"
+	)
 	#
 	CFLAGS="\"$COMMON_CFLAGS\""
 	CXXFLAGS="\"$COMMON_CXXFLAGS\""


### PR DESCRIPTION
This exposes the mingw-w64 `--with-default-msvcrt` option which allows to build a toolchain which links a newer version of the microsoft C library.