### PR TITLE
Add support for the D language

### DIFF
--- a/build
+++ b/build
@@ -301,6 +301,11 @@ while [[ $# > 0 ]]; do
 		;;
 		--with-default-msvcrt=*)
 			MSVCRT_VERSION=${1/--with-default-msvcrt=/}
+			case $MSVCRT_VERSION in
+				msvcr120*|ucrt*)
+					MSVCRT_PHOBOS_OK="yes"
+				;;
+			esac
 		;;
 		--threads=*)
 			THREADS_MODEL=${1/--threads=/}

--- a/library/functions.sh
+++ b/library/functions.sh
@@ -208,6 +208,7 @@ function func_check_languages {
 		for lang in ${langs[@]}; do
 			case $lang in
 				ada|c|c++|fortran|objc|obj-c++) ;;
+				d) D_LANG_ENABLED="yes" ;;
 				*) _lang_err+=" \"$lang\"" ;;
 			esac
 		done

--- a/scripts/gcc-trunk.sh
+++ b/scripts/gcc-trunk.sh
@@ -83,6 +83,9 @@ PKG_CONFIGURE_FLAGS=(
 	--enable-threads=$THREADS_MODEL
 	--enable-libgomp
 	--enable-libatomic
+	$( [[ "$MSVCRT_PHOBOS_OK" == yes && "$D_LANG_ENABLED" == yes ]] \
+		&& echo "--enable-libphobos"
+	)
 	--enable-lto
 	--enable-graphite
 	--enable-checking=release


### PR DESCRIPTION
GCC9 will add support for the D language. This PR adds `d` to the language list. In addition, the `libphobos` D runtime can only be built with recent msvcrt versions. Therefore this PR enables `libphobos` only if D support is enabled and a new msvcrt version is used. This is based on https://github.com/niXman/mingw-builds/pull/469, which should be merged first.