### PR TITLE
gdb: use 7.12 for gcc 4 and 5

### DIFF
--- a/scripts/gdb.sh
+++ b/scripts/gdb.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=$( [[ $GCC_NAME == gcc-4.6* || $GCC_NAME == gcc-4.7* || $GCC_NAME == gcc-4.8.0 ]] && { echo 7.12; } || { echo 8.3; } )
+PKG_VERSION=$( [[ ${BUILD_VERSION:0:1} == 4 || ${BUILD_VERSION:0:1} == 5 ]] && { echo 7.12; } || { echo 8.3; } )
 PKG_NAME=gdb-${PKG_VERSION}
 PKG_DIR_NAME=gdb-${PKG_VERSION}
 PKG_TYPE=.tar.xz


### PR DESCRIPTION
As reported in #486 i686 build of gcc 5 failes on gdb building.  Old gcc versions not fully support std::to_string that was fixed in gcc 6.  I think that forcing to_string support with "-std=c++11 -D_GLIBCXX_USE_C99" flags not good idea(may cause new bugs) and best way to fix i686 builds is to revert back gdb version for gcc 4 and 5 and use gdb 8 for gcc 6+.