### PR TITLE
correct openSSL url

### DIFF
--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -40,7 +40,7 @@ PKG_NAME=openssl-${PKG_VERSION}
 PKG_DIR_NAME=openssl-${PKG_VERSION}
 PKG_TYPE=.tar.gz
 PKG_URLS=(
-	"https://www.openssl.org/source/openssl-${PKG_VERSION}${PKG_TYPE}"
+	"https://www.openssl.org/source/old/1.0.2/openssl-${PKG_VERSION}${PKG_TYPE}"
 )
 
 PKG_PRIORITY=extra


### PR DESCRIPTION
Fix for failing Open SSL download. 1.0.2 is now 'old' and all 1.0.2 release got moved, and previous urls are not valid anymore.