### PR TITLE
Update version detection method

### DIFF
--- a/scripts/gdb.sh
+++ b/scripts/gdb.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=$( [[ ${BUILD_VERSION:0:1} == 4 || ${BUILD_VERSION:0:1} == 5 ]] && { echo 7.12; } || { echo 9.2; } )
+PKG_VERSION=$( [[ `echo $BUILD_VERSION | cut -d. -f1` == 4 || `echo $BUILD_VERSION | cut -d. -f1` == 5 ]] && { echo 7.12; } || { echo 9.2; } )
 PKG_NAME=gdb-${PKG_VERSION}
 PKG_DIR_NAME=gdb-${PKG_VERSION}
 PKG_TYPE=.tar.xz

--- a/scripts/isl.sh
+++ b/scripts/isl.sh
@@ -35,16 +35,16 @@
 
 # **************************************************************************
 
-if [[ ${BUILD_VERSION:0:1} == 4 && ${BUILD_VERSION:2:1} -le 8 ]] || [[ ${BUILD_VERSION:0:1} == 4 && ${BUILD_VERSION:2:1} == 9 && ${BUILD_VERSION:4:1} -le 2 ]]; then
+if [[ `echo $BUILD_VERSION | cut -d. -f1` == 4 && `echo $BUILD_VERSION | cut -d. -f2` -le 8 ]] || [[ `echo $BUILD_VERSION | cut -d. -f1` == 4 && `echo $BUILD_VERSION | cut -d. -f2` == 9 && `echo $BUILD_VERSION | cut -d. -f3` -le 2 ]]; then
    PKG_VERSION=0.12.2
    PKG_TYPE=.tar.lzma
-elif [[ ${BUILD_VERSION:0:1} == 4 ]] || [[ ${BUILD_VERSION:0:1} == 5 && ${BUILD_VERSION:2:1} -le 2 ]]; then
+elif [[ `echo $BUILD_VERSION | cut -d. -f1` == 4 ]] || [[ `echo $BUILD_VERSION | cut -d. -f1` == 5 && `echo $BUILD_VERSION | cut -d. -f2` -le 2 ]]; then
    PKG_VERSION=0.14.1
    PKG_TYPE=.tar.xz
-elif [[ ${BUILD_VERSION:0:1} == 5 ]]; then
+elif [[ `echo $BUILD_VERSION | cut -d. -f1` == 5 ]]; then
    PKG_VERSION=0.18
    PKG_TYPE=.tar.xz
-elif [[ ${BUILD_VERSION:0:1} -le 7 && ${BUILD_VERSION} != trunk ]]; then
+elif [[ `echo $BUILD_VERSION | cut -d. -f1` -le 7 && ${BUILD_VERSION} != trunk ]]; then
    PKG_VERSION=0.19
    PKG_TYPE=.tar.xz
 else

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -63,7 +63,7 @@ pthread_test_list=(
 	"pthread_test.c -mthreads -lpthread -o pthread_test.exe"
 )
 
-[[ ${BUILD_VERSION:0:1} == 4 && ${BUILD_VERSION:2:1} -le 6 ]] && (
+[[ `echo $BUILD_VERSION | cut -d. -f1` == 4 && `echo $BUILD_VERSION | cut -d. -f2` -le 6 ]] && (
 	stdthread_test_list=(
 		"stdthread_test.cpp -std=c++0x -o stdthread_test.exe"
 	)
@@ -85,7 +85,7 @@ time_test_list=(
 	"time_test.c -lpthread -o time_test.exe"
 )
 
-[[ ${BUILD_VERSION:0:1} == 4 && ${BUILD_VERSION:2:1} -le 6 ]] && (
+[[ `echo $BUILD_VERSION | cut -d. -f1` == 4 && `echo $BUILD_VERSION | cut -d. -f2` -le 6 ]] && (
 	sleep_test_list=(
 		"sleep_test.cpp -std=c++0x -o sleep_test.exe"
 	)
@@ -118,5 +118,5 @@ PKG_TESTS["lasterror_test1"]=lasterror_test1_list[@]
 PKG_TESTS["lasterror_test2"]=lasterror_test2_list[@]
 PKG_TESTS["time_test"]=time_test_list[@]
 [[ $THREADS_MODEL == posix ]] && { PKG_TESTS["sleep_test"]=sleep_test_list[@]; }
-[[ ${BUILD_VERSION:0:1} -ge 6 ]] && { PKG_TESTS["random_device"]=random_device_list[@]; }
-[[ ${BUILD_VERSION:0:1} -ge 7 ]] && { PKG_TESTS["filesystem"]=filesystem_list[@]; }
+[[ `echo $BUILD_VERSION | cut -d. -f1` -ge 6 ]] && { PKG_TESTS["random_device"]=random_device_list[@]; }
+[[ `echo $BUILD_VERSION | cut -d. -f1` -ge 7 ]] && { PKG_TESTS["filesystem"]=filesystem_list[@]; }


### PR DESCRIPTION
Previously the scripts assume that GCC's major version has only 1 character, which is now wrong since GCC 10 is released.
Now uses cut to split version string.
Fixes #522 .
