### PR TITLE
Update mingw-w64, binutils, isl and gcc

### DIFF
--- a/build
+++ b/build
@@ -67,9 +67,9 @@ readonly RUN_ARGS="$@"
 	echo "    --static-gcc               - build static GCC"
 	echo "    --dyn-deps                 - build GCC with dynamically dependencies"
 	echo "    --jobs=N                   - specifies number of parallel make threads (defaults to 4)"
-	echo "    --rt-version=<v3|v4|v5|v6|v7|trunk|v3.3.0|v4.0.6|v5.0.4|v6.0.0|v7.0.0> - specifies mingw-w64 runtime version to build"
-	echo "                                 v3, v4, v5, v6, v7, trunk specifies specific branches in the git repo"
-	echo "                                 v3.3.0, v4.0.6, v5.0.4, v6.0.0, v7.0.0 is a specific release versions, uses the tarball"
+	echo "    --rt-version=<v3|v4|v5|v6|v7|v8|trunk|v3.3.0|v4.0.6|v5.0.4|v6.0.0|v7.0.0|v8.0.0> - specifies mingw-w64 runtime version to build"
+	echo "                                 v3, v4, v5, v6, v7, v8, trunk specifies specific branches in the git repo"
+	echo "                                 v3.3.0, v4.0.6, v5.0.4, v6.0.0, v7.0.0, v8.0.0 is a specific release versions, uses the tarball"
 	echo "    --with-default-msvcrt=     - specifies msvc version the toolchain will target"
 	echo "                                 <msvcrt|msvcr80|msvcr90|msvcr100|msvcr110|msvcr120|ucrt>"
 	echo "    --rev=N                    - specifies number of the build revision"
@@ -293,8 +293,12 @@ while [[ $# > 0 ]]; do
 					RUNTIME_VERSION=v7
 					RUNTIME_BRANCH="v7.x"
 				;;
+				v8)
+					RUNTIME_VERSION=v8
+					RUNTIME_BRANCH="v8.x"
+				;;
 				trunk)
-					RUNTIME_VERSION=v7
+					RUNTIME_VERSION=v8
 					RUNTIME_BRANCH="master"
 				;;
 				v3.3.0)
@@ -315,6 +319,10 @@ while [[ $# > 0 ]]; do
 				;;
 				v7.0.0)
 					RUNTIME_VERSION=v7.0.0
+					RUNTIME_BRANCH="release"
+				;;
+				v8.0.0)
+					RUNTIME_VERSION=v8.0.0
 					RUNTIME_BRANCH="release"
 				;;
 				*)

--- a/patches/gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
+++ b/patches/gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
@@ -1,0 +1,53 @@
+From 05b0bb43124b041da360ba9adcbaab8430be6d18 Mon Sep 17 00:00:00 2001
+From: Liu Hao <lh_mouse@126.com>
+Date: Wed, 6 May 2020 21:49:18 +0800
+Subject: [PATCH] libgomp: Don't hard-code MS printf attributes
+
+---
+ libgomp/libgomp.h | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/libgomp/libgomp.h b/libgomp/libgomp.h
+index c98c1452bd4..0cc8443f6c2 100644
+--- a/libgomp/libgomp.h
++++ b/libgomp/libgomp.h
+@@ -69,6 +69,13 @@
+ # endif
+ #endif
+ 
++#include <stdio.h>
++#ifdef __MINGW_PRINTF_FORMAT
++#define PRINTF_FORMAT __MINGW_PRINTF_FORMAT
++#else
++#define PRINTF_FORMAT printf
++#endif
++
+ #ifdef HAVE_ATTRIBUTE_VISIBILITY
+ # pragma GCC visibility push(hidden)
+ #endif
+@@ -180,7 +187,7 @@ extern void gomp_aligned_free (void *);
+ 
+ extern void gomp_vdebug (int, const char *, va_list);
+ extern void gomp_debug (int, const char *, ...)
+-	__attribute__ ((format (printf, 2, 3)));
++	__attribute__ ((format (PRINTF_FORMAT, 2, 3)));
+ #define gomp_vdebug(KIND, FMT, VALIST) \
+   do { \
+     if (__builtin_expect (gomp_debug_var, 0)) \
+@@ -193,11 +200,11 @@ extern void gomp_debug (int, const char *, ...)
+   } while (0)
+ extern void gomp_verror (const char *, va_list);
+ extern void gomp_error (const char *, ...)
+-	__attribute__ ((format (printf, 1, 2)));
++	__attribute__ ((format (PRINTF_FORMAT, 1, 2)));
+ extern void gomp_vfatal (const char *, va_list)
+ 	__attribute__ ((noreturn));
+ extern void gomp_fatal (const char *, ...)
+-	__attribute__ ((noreturn, format (printf, 1, 2)));
++	__attribute__ ((noreturn, format (PRINTF_FORMAT, 1, 2)));
+ 
+ struct gomp_task;
+ struct gomp_taskgroup;
+-- 
+2.26.2
+

--- a/scripts/binutils.sh
+++ b/scripts/binutils.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=2.35
+PKG_VERSION=2.35.1
 PKG_NAME=binutils-${PKG_VERSION}
 [[ $USE_MULTILIB == yes ]] && {
 	PKG_NAME=$BUILD_ARCHITECTURE-$PKG_NAME-multi

--- a/scripts/gcc-10.2.0.sh
+++ b/scripts/gcc-10.2.0.sh
@@ -60,6 +60,7 @@ PKG_PATCHES=(
 	gcc/gcc-5.1.0-fix-libatomic-building-for-threads=win32.patch
 	gcc/gcc-10-ktietz-libgomp.patch
 	gcc/gcc-libgomp-ftime64.patch
+	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
 )
 
 #

--- a/scripts/isl.sh
+++ b/scripts/isl.sh
@@ -48,7 +48,7 @@ elif [[ `echo $BUILD_VERSION | cut -d. -f1` -le 7 && ${BUILD_VERSION} != trunk ]
    PKG_VERSION=0.19
    PKG_TYPE=.tar.xz
 else
-   PKG_VERSION=0.22.1
+   PKG_VERSION=0.23
    PKG_TYPE=.tar.xz
 fi
 PKG_NAME=$BUILD_ARCHITECTURE-isl-${PKG_VERSION}-$LINK_TYPE_SUFFIX


### PR DESCRIPTION
See https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch. Fixes gcc-10.2.0 build.
