### PR TITLE
library/config-win.sh: Reduce pacman calls when looking for required packaes. 

### DIFF
--- a/library/config-win.sh
+++ b/library/config-win.sh
@@ -78,6 +78,8 @@ readonly LOGVIEWERS=(
 # **************************************************************************
 
 function func_test_installed_packages {
+	local installed_packages=($(pacman -Qq))
+
 	local required_packages=(
 		lndir
 		git
@@ -87,7 +89,7 @@ function func_test_installed_packages {
 		p7zip
 		make
 		patch
-		automake
+		automake-wrapper
 		autoconf
 		libtool
 		flex
@@ -103,11 +105,9 @@ function func_test_installed_packages {
 
 	local not_installed_packages=()
 
-	for it in ${required_packages[@]}; do
-		$(pacman -Qs ^$it > /dev/null 2>&1)
-		[[ $? != 0 ]] && {
-			not_installed_packages=(${not_installed_packages[@]} $it)
-		}
+	for req in "${required_packages[@]}"; do
+		[[ ! "${installed_packages[*]}" =~ " $req " ]] &&
+			not_installed_packages=(${not_installed_packages[@]} $req)
 	done
 
 	[[ ${#not_installed_packages[@]} != 0 ]] && {


### PR DESCRIPTION
Creating processes in Windows is rather costly compared to Linux, for example.

Instead of calling `pacman` to see if each of the required packages is installed, it's substantially faster to use an array with the ones
installed and then check against it for matches. Even though I used `=~` for a regex match I think the quotes on the right side would make it match literally, which is not a problem anyway and it's still more readable than an explicit double loop.

By the way, `automake` is provided by `automake-wrapper` in MSYS2 so its package name had to be changed or it wouldn't be correctly identified otherwise.