### PR TITLE
Apply MS printf attributes patch to gcc 6.5.0

### DIFF
--- a/scripts/gcc-6.5.0.sh
+++ b/scripts/gcc-6.5.0.sh
@@ -63,6 +63,7 @@ PKG_PATCHES=(
 	gcc/gcc-6.1-disable-weak-refs.patch
 	gcc/gcc-6.5.0-filesystem.patch
 	gcc/gcc-libgomp-ftime64.patch
+	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
 )
 
 #


### PR DESCRIPTION
Fixes #562

I manually applied to patch and I can confirm it fixed the errors during compilation.