### PR TITLE
Add `--noconfirm` to skip confirm

### DIFF
--- a/library/config-win.sh
+++ b/library/config-win.sh
@@ -101,9 +101,9 @@ function func_test_installed_packages {
 		dejagnu
 	)
 
-    echo "--> installing required packages..."
-    pacman -Sy --needed$(printf " %s" "${required_packages[@]}") ||
-        return 1
+	echo "--> installing required packages..."
+	pacman -Sy --noconfirm --needed$(printf " %s" "${required_packages[@]}") ||
+		return 1
 
 	return 0
 }


### PR DESCRIPTION
``` patch
diff --git a/library/config-win.sh b/library/config-win.sh
index 8adb5f0..f7a0bf0 100644
--- a/library/config-win.sh
+++ b/library/config-win.sh
@@ -101,9 +101,9 @@ function func_test_installed_packages {
 		dejagnu
 	)
 
-    echo "--> installing required packages..."
-    pacman -Sy --needed$(printf " %s" "${required_packages[@]}") ||
-        return 1
+	echo "--> installing required packages..."
+	pacman -Sy --noconfirm --needed$(printf " %s" "${required_packages[@]}") ||
+		return 1
 
 	return 0
 }
```