### PR TITLE
PCH fix by using -Wl,--disable-dynamicbase for boot-ldflags

### DIFF
--- a/patches/gcc/gcc-10-libgcc-ldflags.patch
+++ b/patches/gcc/gcc-10-libgcc-ldflags.patch
@@ -1,0 +1,19 @@
+--- a/libgcc/Makefile.in	2020-08-29 23:18:54.246729700 -0700
++++ b/libgcc/Makefile.in	2020-08-29 23:23:26.754578500 -0700
+@@ -84,6 +84,7 @@
+
+ CC = @CC@
+ CFLAGS = @CFLAGS@
++LDFLAGS = @LDFLAGS@
+ RANLIB = @RANLIB@
+ LN_S = @LN_S@
+
+@@ -991,7 +992,7 @@
+ 	# @multilib_dir@ is not really necessary, but sometimes it has
+ 	# more uses than just a directory name.
+ 	$(mkinstalldirs) $(MULTIDIR)
+-	$(subst @multilib_flags@,$(CFLAGS) -B./,$(subst \
++	$(subst @multilib_flags@,$(CFLAGS) -B./ $(LDFLAGS),$(subst \
+ 		@multilib_dir@,$(MULTIDIR),$(subst \
+ 		@shlib_objs@,$(objects) libgcc.a,$(subst \
+ 		@shlib_base_name@,libgcc_s,$(subst \

--- a/scripts/gcc-11.2.0.sh
+++ b/scripts/gcc-11.2.0.sh
@@ -61,6 +61,7 @@ PKG_PATCHES=(
 	gcc/gcc-10-ktietz-libgomp.patch
 	gcc/gcc-libgomp-ftime64.patch
 	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
+	gcc/gcc-10-libgcc-ldflags.patch
 )
 
 #
@@ -130,6 +131,7 @@ PKG_CONFIGURE_FLAGS=(
 	CPPFLAGS="\"$COMMON_CPPFLAGS\""
 	LDFLAGS="\"$COMMON_LDFLAGS $( [[ $BUILD_ARCHITECTURE == i686 ]] && echo -Wl,--large-address-aware )\""
 	LD_FOR_TARGET=$PREFIX/bin/ld.exe
+	--with-boot-ldflags="\"$LDFLAGS -Wl,--disable-dynamicbase -static-libstdc++ -static-libgcc\""
 )
 
 #


### PR DESCRIPTION
Building GCC 11.2.0 resulted in a build that had problem with PCHs,
due to the nature how PCHs are implemented in GCC on Windows.

-Wl,--disable-dynamicbase is needed due to binutils 2.36 having
enabled ASLR by default.