### PR TITLE
GitHub Actions: Add x86_64 and i686 release builds

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -1,0 +1,166 @@
+name: x86_64 and i686 release builds
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "x86_64 posix sjlj",
+            artifact: "x86_64-11.2.0-release-posix-sjlj-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
+          }
+        - {
+            name: "x86_64 posix seh",
+            artifact: "x86_64-11.2.0-release-posix-seh-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
+          }
+        - {
+            name: "x86_64 win32 sjlj",
+            artifact: "x86_64-11.2.0-release-win32-sjlj-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
+          }
+        - {
+            name: "x86_64 win32 seh",
+            artifact: "x86_64-11.2.0-release-win32-seh-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
+          }
+        - {
+            name: "i686 posix sjlj",
+            artifact: "i686-11.2.0-release-posix-sjlj-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
+          }
+        - {
+            name: "i686 posix dwarf",
+            artifact: "i686-11.2.0-release-posix-dwarf-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
+          }
+        - {
+            name: "i686 win32 sjlj",
+            artifact: "i686-11.2.0-release-win32-sjlj-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
+          }
+        - {
+            name: "i686 win32 dwarf",
+            artifact: "i686-11.2.0-release-win32-dwarf-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
+          }
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: msys2/setup-msys2@v2
+      with:
+        update: true
+
+    - name: Build
+      shell: msys2 {0}
+      run: ./build ${{ matrix.config.build_cmd }}
+
+    - name: Upload
+      uses: actions/upload-artifact@v1
+      with:
+        path: ./buildroot/archives/${{ matrix.config.artifact }}
+        name: ${{ matrix.config.artifact }}
+
+  release:
+    if: contains(github.ref, 'tags/v')
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Store Release url
+      run: |
+        echo "${{ steps.create_release.outputs.upload_url }}" > ./upload_url
+
+    - uses: actions/upload-artifact@v1
+      with:
+        path: ./upload_url
+        name: upload_url
+
+  publish:
+    if: contains(github.ref, 'tags/v')
+    name: ${{ matrix.config.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "x86_64 posix sjlj",
+            artifact: "x86_64-11.2.0-release-posix-sjlj-rt_v9-rev0.7z"
+          }
+        - {
+            name: "x86_64 posix seh",
+            artifact: "x86_64-11.2.0-release-posix-seh-rt_v9-rev0.7z"
+          }
+        - {
+            name: "x86_64 win32 sjlj",
+            artifact: "x86_64-11.2.0-release-win32-sjlj-rt_v9-rev0.7z"
+          }
+        - {
+            name: "x86_64 win32 seh",
+            artifact: "x86_64-11.2.0-release-win32-seh-rt_v9-rev0.7z"
+          }
+        - {
+            name: "i686 posix sjlj",
+            artifact: "i686-11.2.0-release-posix-sjlj-rt_v9-rev0.7z"
+          }
+        - {
+            name: "i686 posix dwarf",
+            artifact: "i686-11.2.0-release-posix-dwarf-rt_v9-rev0.7z"
+          }
+        - {
+            name: "i686 win32 sjlj",
+            artifact: "i686-11.2.0-release-win32-sjlj-rt_v9-rev0.7z"
+          }
+        - {
+            name: "i686 win32 dwarf",
+            artifact: "i686-11.2.0-release-win32-dwarf-rt_v9-rev0.7z"
+          }
+
+    needs: release
+
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: ${{ matrix.config.artifact }}
+        path: ./
+
+    - name: Download URL
+      uses: actions/download-artifact@v1
+      with:
+        name: upload_url
+        path: ./
+    - id: set_upload_url
+      run: |
+        upload_url=`cat ./upload_url`
+        echo ::set-output name=upload_url::$upload_url
+
+    - name: Upload to Release
+      id: upload_to_release
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.set_upload_url.outputs.upload_url }}
+        asset_path: ./${{ matrix.config.artifact }}
+        asset_name: ${{ matrix.config.artifact }}
+        asset_content_type: application/x-gtar


### PR DESCRIPTION
The yaml file will build gcc 11.2.0 with runtime v9 in all configurations present in the 8.1 published on [sourceforge](https://sourceforge.net/projects/mingw-w64/files/):

 *  x86_64-posix-sjlj
 *  x86_64-posix-seh
 *  x86_64-win32-sjlj
 *  x86_64-win32-seh
 *  i686-posix-sjlj
 *  i686-posix-dwarf
 *  i686-win32-sjlj
 *  i686-win32-dwarf 

When tagging a release and pushing that tag the build artifacts will be uploaded to the release tag and can be downloaded without having a github account. See my [v11.2.0 release tag](https://github.com/cristianadam/mingw-builds/releases/tag/v11.2.0).

```
git tag -a v11.2.0 -m "Release v11.2.0"
git push origin v11.2.0
```
