### PR TITLE
binutils: upgrade to version 2.38

### DIFF
--- a/patches/binutils/0110-binutils-mingw-gnu-print.patch
+++ b/patches/binutils/0110-binutils-mingw-gnu-print.patch
@@ -1,7 +1,7 @@
-diff -urN binutils-2.37.orig/bfd/bfd-in.h binutils-2.37/bfd/bfd-in.h
---- binutils-2.37.orig/bfd/bfd-in.h	2021-07-08 19:37:19.000000000 +0800
-+++ binutils-2.37/bfd/bfd-in.h	2021-08-01 11:10:24.948855200 +0800
-@@ -126,7 +126,7 @@
+diff -urN binutils-2.38.orig/bfd/bfd-in.h binutils-2.38/bfd/bfd-in.h
+--- binutils-2.38.orig/bfd/bfd-in.h	2022-01-22 13:14:07.000000000 +0100
++++ binutils-2.38/bfd/bfd-in.h	2022-04-01 16:18:40.062376800 +0200
+@@ -123,7 +123,7 @@
  
  #if BFD_HOST_64BIT_LONG
  #define BFD_VMA_FMT "l"
@@ -10,10 +10,10 @@ diff -urN binutils-2.37.orig/bfd/bfd-in.h binutils-2.37/bfd/bfd-in.h
  #define BFD_VMA_FMT "I64"
  #else
  #define BFD_VMA_FMT "ll"
-diff -urN binutils-2.37.orig/bfd/bfd-in2.h binutils-2.37/bfd/bfd-in2.h
---- binutils-2.37.orig/bfd/bfd-in2.h	2021-07-08 19:37:19.000000000 +0800
-+++ binutils-2.37/bfd/bfd-in2.h	2021-08-01 11:10:41.655887600 +0800
-@@ -133,7 +133,7 @@
+diff -urN binutils-2.38.orig/bfd/bfd-in2.h binutils-2.38/bfd/bfd-in2.h
+--- binutils-2.38.orig/bfd/bfd-in2.h	2022-01-22 13:14:07.000000000 +0100
++++ binutils-2.38/bfd/bfd-in2.h	2022-04-01 16:19:30.593721500 +0200
+@@ -130,7 +130,7 @@
  
  #if BFD_HOST_64BIT_LONG
  #define BFD_VMA_FMT "l"
@@ -22,9 +22,9 @@ diff -urN binutils-2.37.orig/bfd/bfd-in2.h binutils-2.37/bfd/bfd-in2.h
  #define BFD_VMA_FMT "I64"
  #else
  #define BFD_VMA_FMT "ll"
-diff -urN binutils-2.37.orig/binutils/dwarf.c binutils-2.37/binutils/dwarf.c
---- binutils-2.37.orig/binutils/dwarf.c	2021-07-08 19:37:19.000000000 +0800
-+++ binutils-2.37/binutils/dwarf.c	2021-08-01 11:11:10.369398700 +0800
+diff -urN binutils-2.38.orig/binutils/dwarf.c binutils-2.38/binutils/dwarf.c
+--- binutils-2.38.orig/binutils/dwarf.c	2022-01-22 13:14:07.000000000 +0100
++++ binutils-2.38/binutils/dwarf.c	2022-04-01 16:20:13.920951900 +0200
 @@ -218,7 +218,7 @@
  }
  
@@ -34,10 +34,10 @@ diff -urN binutils-2.37.orig/binutils/dwarf.c binutils-2.37/binutils/dwarf.c
  #  define DWARF_VMA_FMT		"ll"
  #  define DWARF_VMA_FMT_LONG	"%16.16llx"
  # else
-diff -urN binutils-2.37.orig/binutils/nm.c binutils-2.37/binutils/nm.c
---- binutils-2.37.orig/binutils/nm.c	2021-07-08 19:37:19.000000000 +0800
-+++ binutils-2.37/binutils/nm.c	2021-08-01 11:11:32.715864900 +0800
-@@ -1312,7 +1312,7 @@
+diff -urN binutils-2.38.orig/binutils/nm.c binutils-2.38/binutils/nm.c
+--- binutils-2.38.orig/binutils/nm.c	2022-01-22 13:14:07.000000000 +0100
++++ binutils-2.38/binutils/nm.c	2022-04-01 16:21:05.889862000 +0200
+@@ -1556,7 +1556,7 @@
  #if BFD_HOST_64BIT_LONG
        ;
  #elif BFD_HOST_64BIT_LONG_LONG
@@ -46,9 +46,9 @@ diff -urN binutils-2.37.orig/binutils/nm.c binutils-2.37/binutils/nm.c
        length = "ll";
  #else
        length = "I64";
-diff -urN binutils-2.37.orig/binutils/prdbg.c binutils-2.37/binutils/prdbg.c
---- binutils-2.37.orig/binutils/prdbg.c	2021-07-08 19:37:19.000000000 +0800
-+++ binutils-2.37/binutils/prdbg.c	2021-08-01 11:11:43.981937700 +0800
+diff -urN binutils-2.38.orig/binutils/prdbg.c binutils-2.38/binutils/prdbg.c
+--- binutils-2.38.orig/binutils/prdbg.c	2022-01-22 13:14:07.000000000 +0100
++++ binutils-2.38/binutils/prdbg.c	2022-04-01 16:21:51.875019800 +0200
 @@ -497,7 +497,7 @@
  #if BFD_HOST_64BIT_LONG_LONG
    else if (sizeof (vma) <= sizeof (unsigned long long))
@@ -58,40 +58,40 @@ diff -urN binutils-2.37.orig/binutils/prdbg.c binutils-2.37/binutils/prdbg.c
        if (hexp)
  	sprintf (buf, "0x%llx", (unsigned long long) vma);
        else if (unsignedp)
-diff -urN binutils-2.37.orig/binutils/strings.c binutils-2.37/binutils/strings.c
---- binutils-2.37.orig/binutils/strings.c	2021-07-08 19:37:19.000000000 +0800
-+++ binutils-2.37/binutils/strings.c	2021-08-01 11:12:04.006375800 +0800
-@@ -610,7 +610,7 @@
- 	  case 8:
- 	    if (sizeof (start) > sizeof (long))
- 	      {
+diff -urN binutils-2.38.orig/binutils/strings.c binutils-2.38/binutils/strings.c
+--- binutils-2.38.orig/binutils/strings.c	2022-01-22 13:14:07.000000000 +0100
++++ binutils-2.38/binutils/strings.c	2022-04-01 16:23:19.687330400 +0200
+@@ -617,7 +617,7 @@
+     case 8:
+       if (sizeof (address) > sizeof (long))
+ 	{
 -#ifndef __MSVCRT__
 +#if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)
- 		printf ("%7llo ", (unsigned long long) start);
+ 	  printf ("%7llo ", (unsigned long long) address);
  #else
- 		printf ("%7I64o ", (unsigned long long) start);
-@@ -623,7 +623,7 @@
- 	  case 10:
- 	    if (sizeof (start) > sizeof (long))
- 	      {
+ 	  printf ("%7I64o ", (unsigned long long) address);
+@@ -630,7 +630,7 @@
+     case 10:
+       if (sizeof (address) > sizeof (long))
+ 	{
 -#ifndef __MSVCRT__
 +#if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)
- 		printf ("%7llu ", (unsigned long long) start);
+ 	  printf ("%7llu ", (unsigned long long) address);
  #else
- 		printf ("%7I64d ", (unsigned long long) start);
-@@ -636,7 +636,7 @@
- 	  case 16:
- 	    if (sizeof (start) > sizeof (long))
- 	      {
+ 	  printf ("%7I64d ", (unsigned long long) address);
+@@ -643,7 +643,7 @@
+     case 16:
+       if (sizeof (address) > sizeof (long))
+ 	{
 -#ifndef __MSVCRT__
 +#if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)
- 		printf ("%7llx ", (unsigned long long) start);
+ 	  printf ("%7llx ", (unsigned long long) address);
  #else
- 		printf ("%7I64x ", (unsigned long long) start);
-diff -urN binutils-2.37.orig/gas/as.h binutils-2.37/gas/as.h
---- binutils-2.37.orig/gas/as.h	2021-07-08 19:37:19.000000000 +0800
-+++ binutils-2.37/gas/as.h	2021-08-01 11:12:40.156606600 +0800
-@@ -405,10 +405,10 @@
+ 	  printf ("%7I64x ", (unsigned long long) address);
+diff -urN binutils-2.38.orig/gas/as.h binutils-2.38/gas/as.h
+--- binutils-2.38.orig/gas/as.h	2022-01-22 13:14:08.000000000 +0100
++++ binutils-2.38/gas/as.h	2022-04-01 16:24:32.374816400 +0200
+@@ -413,10 +413,10 @@
  
  #define PRINTF_LIKE(FCN) \
    void FCN (const char *format, ...) \
@@ -104,10 +104,10 @@ diff -urN binutils-2.37.orig/gas/as.h binutils-2.37/gas/as.h
  
  #else /* __GNUC__ < 2 || defined(VMS) */
  
-diff -urN binutils-2.37.orig/gold/configure binutils-2.37/gold/configure
---- binutils-2.37.orig/gold/configure	2021-07-19 00:40:53.000000000 +0800
-+++ binutils-2.37/gold/configure	2021-08-01 11:13:20.977363000 +0800
-@@ -10153,7 +10153,7 @@
+diff -urN binutils-2.38.orig/gold/configure binutils-2.38/gold/configure
+--- binutils-2.38.orig/gold/configure	2022-01-22 13:25:13.000000000 +0100
++++ binutils-2.38/gold/configure	2022-04-01 16:25:19.092799300 +0200
+@@ -10204,7 +10204,7 @@
  /* end confdefs.h.  */
  
  template<typename T> extern void foo(const char*, ...)
@@ -116,10 +116,10 @@ diff -urN binutils-2.37.orig/gold/configure binutils-2.37/gold/configure
  template<typename T> void foo(const char* format, ...) {}
  void bar() { foo<int>("%s\n", "foo"); }
  
-diff -urN binutils-2.37.orig/gold/configure.ac binutils-2.37/gold/configure.ac
---- binutils-2.37.orig/gold/configure.ac	2021-07-08 19:37:20.000000000 +0800
-+++ binutils-2.37/gold/configure.ac	2021-08-01 11:13:28.640398400 +0800
-@@ -678,7 +678,7 @@
+diff -urN binutils-2.38.orig/gold/configure.ac binutils-2.38/gold/configure.ac
+--- binutils-2.38.orig/gold/configure.ac	2022-01-22 13:14:09.000000000 +0100
++++ binutils-2.38/gold/configure.ac	2022-04-01 16:25:56.733450400 +0200
+@@ -679,7 +679,7 @@
  [gold_cv_template_attribute],
  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([
  template<typename T> extern void foo(const char*, ...)
@@ -128,9 +128,9 @@ diff -urN binutils-2.37.orig/gold/configure.ac binutils-2.37/gold/configure.ac
  template<typename T> void foo(const char* format, ...) {}
  void bar() { foo<int>("%s\n", "foo"); }
  ])], [gold_cv_template_attribute=yes], [gold_cv_template_attribute=no])])
-diff -urN binutils-2.37.orig/include/ansidecl.h binutils-2.37/include/ansidecl.h
---- binutils-2.37.orig/include/ansidecl.h	2021-07-08 19:37:20.000000000 +0800
-+++ binutils-2.37/include/ansidecl.h	2021-08-01 11:13:57.084307400 +0800
+diff -urN binutils-2.38.orig/include/ansidecl.h binutils-2.38/include/ansidecl.h
+--- binutils-2.38.orig/include/ansidecl.h	2022-01-22 13:14:09.000000000 +0100
++++ binutils-2.38/include/ansidecl.h	2022-04-01 16:26:58.905567000 +0200
 @@ -195,7 +195,7 @@
     before GCC 3.3, but as of 3.3 we need to add the `nonnull'
     attribute to retain this behavior.  */

--- a/scripts/binutils.sh
+++ b/scripts/binutils.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=2.37
+PKG_VERSION=2.38
 PKG_NAME=binutils-${PKG_VERSION}
 [[ $USE_MULTILIB == yes ]] && {
 	PKG_NAME=$BUILD_ARCHITECTURE-$PKG_NAME-multi


### PR DESCRIPTION
Binutils 2.38 has fixes that would allow building of large applications such as QtWebkit, due to a fix for file handle leaks in the toolchain.