### PR TITLE
Fix "logviewer not found" on win11

### DIFF
--- a/library/config-win.sh
+++ b/library/config-win.sh
@@ -58,6 +58,7 @@ readonly REPOSITORY_FILE="$PROJECT_ROOT_URL/files/Toolchains targetting Win32/Pe
 readonly LOGVIEWERS=(
 	"c:/progra~2/notepad++/notepad++.exe"
 	"c:/progra~1/notepad++/notepad++.exe"
+	"$USERPROFILE/AppData/Local/Microsoft/WindowsApps/notepad"
 	"notepad"
 )
 


### PR DESCRIPTION
Windows 11 moves `nodepad.exe` from `C:\Windows\System32` to the Appdata folder which is not in the PATH of msys2. This causes a “file not found” error when starting notepad directly.

This PR adds the correct `notepad.exe` path of Windows 11 to the logviewer.