### PR TITLE
Add GCC 12.1.0 and MinGW Runtime v10

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -12,43 +12,43 @@ jobs:
         config:
         - {
             name: "x86_64 posix sjlj",
-            artifact: "x86_64-12.1.0-release-posix-sjlj-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            artifact: "x86_64-11.2.0-release-posix-sjlj-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "x86_64 posix seh",
-            artifact: "x86_64-12.1.0-release-posix-seh-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            artifact: "x86_64-11.2.0-release-posix-seh-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "x86_64 win32 sjlj",
-            artifact: "x86_64-12.1.0-release-win32-sjlj-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            artifact: "x86_64-11.2.0-release-win32-sjlj-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "x86_64 win32 seh",
-            artifact: "x86_64-12.1.0-release-win32-seh-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            artifact: "x86_64-11.2.0-release-win32-seh-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "i686 posix sjlj",
-            artifact: "i686-12.1.0-release-posix-sjlj-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
+            artifact: "i686-11.2.0-release-posix-sjlj-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "i686 posix dwarf",
-            artifact: "i686-12.1.0-release-posix-dwarf-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
+            artifact: "i686-11.2.0-release-posix-dwarf-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "i686 win32 sjlj",
-            artifact: "i686-12.1.0-release-win32-sjlj-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
+            artifact: "i686-11.2.0-release-win32-sjlj-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "i686 win32 dwarf",
-            artifact: "i686-12.1.0-release-win32-dwarf-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
+            artifact: "i686-11.2.0-release-win32-dwarf-rt_v9-rev0.7z",
+            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
           }
 
     steps:
@@ -104,35 +104,35 @@ jobs:
         config:
         - {
             name: "x86_64 posix sjlj",
-            artifact: "x86_64-12.1.0-release-posix-sjlj-rt_v10-rev0.7z"
+            artifact: "x86_64-11.2.0-release-posix-sjlj-rt_v9-rev0.7z"
           }
         - {
             name: "x86_64 posix seh",
-            artifact: "x86_64-12.1.0-release-posix-seh-rt_v10-rev0.7z"
+            artifact: "x86_64-11.2.0-release-posix-seh-rt_v9-rev0.7z"
           }
         - {
             name: "x86_64 win32 sjlj",
-            artifact: "x86_64-12.1.0-release-win32-sjlj-rt_v10-rev0.7z"
+            artifact: "x86_64-11.2.0-release-win32-sjlj-rt_v9-rev0.7z"
           }
         - {
             name: "x86_64 win32 seh",
-            artifact: "x86_64-12.1.0-release-win32-seh-rt_v10-rev0.7z"
+            artifact: "x86_64-11.2.0-release-win32-seh-rt_v9-rev0.7z"
           }
         - {
             name: "i686 posix sjlj",
-            artifact: "i686-12.1.0-release-posix-sjlj-rt_v10-rev0.7z"
+            artifact: "i686-11.2.0-release-posix-sjlj-rt_v9-rev0.7z"
           }
         - {
             name: "i686 posix dwarf",
-            artifact: "i686-12.1.0-release-posix-dwarf-rt_v10-rev0.7z"
+            artifact: "i686-11.2.0-release-posix-dwarf-rt_v9-rev0.7z"
           }
         - {
             name: "i686 win32 sjlj",
-            artifact: "i686-12.1.0-release-win32-sjlj-rt_v10-rev0.7z"
+            artifact: "i686-11.2.0-release-win32-sjlj-rt_v9-rev0.7z"
           }
         - {
             name: "i686 win32 dwarf",
-            artifact: "i686-12.1.0-release-win32-dwarf-rt_v10-rev0.7z"
+            artifact: "i686-11.2.0-release-win32-dwarf-rt_v9-rev0.7z"
           }
 
     needs: release

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -12,43 +12,43 @@ jobs:
         config:
         - {
             name: "x86_64 posix sjlj",
-            artifact: "x86_64-11.2.0-release-posix-sjlj-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            artifact: "x86_64-12.1.0-release-posix-sjlj-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "x86_64 posix seh",
-            artifact: "x86_64-11.2.0-release-posix-seh-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            artifact: "x86_64-12.1.0-release-posix-seh-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "x86_64 win32 sjlj",
-            artifact: "x86_64-11.2.0-release-win32-sjlj-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            artifact: "x86_64-12.1.0-release-win32-sjlj-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "x86_64 win32 seh",
-            artifact: "x86_64-11.2.0-release-win32-seh-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            artifact: "x86_64-12.1.0-release-win32-seh-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "i686 posix sjlj",
-            artifact: "i686-11.2.0-release-posix-sjlj-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
+            artifact: "i686-12.1.0-release-posix-sjlj-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "i686 posix dwarf",
-            artifact: "i686-11.2.0-release-posix-dwarf-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
+            artifact: "i686-12.1.0-release-posix-dwarf-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "i686 win32 sjlj",
-            artifact: "i686-11.2.0-release-win32-sjlj-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
+            artifact: "i686-12.1.0-release-win32-sjlj-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "i686 win32 dwarf",
-            artifact: "i686-11.2.0-release-win32-dwarf-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
+            artifact: "i686-12.1.0-release-win32-dwarf-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
           }
 
     steps:
@@ -104,35 +104,35 @@ jobs:
         config:
         - {
             name: "x86_64 posix sjlj",
-            artifact: "x86_64-11.2.0-release-posix-sjlj-rt_v9-rev0.7z"
+            artifact: "x86_64-12.1.0-release-posix-sjlj-rt_v10-rev0.7z"
           }
         - {
             name: "x86_64 posix seh",
-            artifact: "x86_64-11.2.0-release-posix-seh-rt_v9-rev0.7z"
+            artifact: "x86_64-12.1.0-release-posix-seh-rt_v10-rev0.7z"
           }
         - {
             name: "x86_64 win32 sjlj",
-            artifact: "x86_64-11.2.0-release-win32-sjlj-rt_v9-rev0.7z"
+            artifact: "x86_64-12.1.0-release-win32-sjlj-rt_v10-rev0.7z"
           }
         - {
             name: "x86_64 win32 seh",
-            artifact: "x86_64-11.2.0-release-win32-seh-rt_v9-rev0.7z"
+            artifact: "x86_64-12.1.0-release-win32-seh-rt_v10-rev0.7z"
           }
         - {
             name: "i686 posix sjlj",
-            artifact: "i686-11.2.0-release-posix-sjlj-rt_v9-rev0.7z"
+            artifact: "i686-12.1.0-release-posix-sjlj-rt_v10-rev0.7z"
           }
         - {
             name: "i686 posix dwarf",
-            artifact: "i686-11.2.0-release-posix-dwarf-rt_v9-rev0.7z"
+            artifact: "i686-12.1.0-release-posix-dwarf-rt_v10-rev0.7z"
           }
         - {
             name: "i686 win32 sjlj",
-            artifact: "i686-11.2.0-release-win32-sjlj-rt_v9-rev0.7z"
+            artifact: "i686-12.1.0-release-win32-sjlj-rt_v10-rev0.7z"
           }
         - {
             name: "i686 win32 dwarf",
-            artifact: "i686-11.2.0-release-win32-dwarf-rt_v9-rev0.7z"
+            artifact: "i686-12.1.0-release-win32-dwarf-rt_v10-rev0.7z"
           }
 
     needs: release

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In order to use the scripts provided by the MinGW-W64 project it is needed:
   --no-multilib                       - build GCC without multilib support (default for DWARF and SEH exception models).
   --static-gcc                        - build static GCC.
   --dyn-deps                          - build GCC with dynamically dependencies.
-  --rt-version=<v3|v4|v5|v6|v7|v8|v9> - version of mingw-w64 runtime to build.
+  --rt-version=<v3..v10>              - version of mingw-w64 runtime to build.
   --rev=N                             - number of the build revision.
   --with-testsuite                    - run testsuite for packages that contain flags for it.
   --threads=<posix|win32>             - used threads model.
@@ -126,6 +126,7 @@ At the moment, successfully building the following versions:
   gcc-11.1.0
   gcc-11.2.0
   gcc-11.3.0
+  gcc-12.1.0
   gcc-4.6-branch (currently 4.6.5 prerelease)
   gcc-4.7-branch (currently 4.7.5 prerelease)
   gcc-4.8-branch (currently 4.8.6 prerelease)
@@ -137,6 +138,7 @@ At the moment, successfully building the following versions:
   gcc-9-branch (currently 9.5.0-prerelease)
   gcc-10-branch (currently 10.4.0-prerelease)
   gcc-11-branch (currently 11.3.0-prerelease)
+  gcc-12-branch (currently 12.2.0-prerelease)
   gcc-trunk (currently 12.0.0 snapshot)
 ```
 

--- a/build
+++ b/build
@@ -68,9 +68,9 @@ readonly RUN_ARGS="$@"
 	echo "    --static-gcc               - build static GCC"
 	echo "    --dyn-deps                 - build GCC with dynamically dependencies"
 	echo "    --jobs=N                   - specifies number of parallel make threads (defaults to 4)"
-	echo "    --rt-version=<v3|v4|v5|v6|v7|v8|v9|trunk|v3.3.0|v4.0.6|v5.0.4|v6.0.0|v7.0.0|v8.0.2|v9.0.0> - specifies mingw-w64 runtime version to build"
-	echo "                                 v3, v4, v5, v6, v7, v8, v9, trunk specifies specific branches in the git repo"
-	echo "                                 v3.3.0, v4.0.6, v5.0.4, v6.0.0, v7.0.0, v8.0.2, v9.0.0 is a specific release versions, uses the tarball"
+	echo "    --rt-version=<version>     - specifies mingw-w64 runtime version to build"
+	echo "                                 v3, v4, v5, v6, v7, v8, v9, v10, trunk specifies specific branches in the git repo"
+	echo "                                 v3.3.0, v4.0.6, v5.0.4, v6.0.0, v7.0.0, v8.0.2, v9.0.0, v10.0.0 is a specific release versions, uses the tarball"
 	echo "    --with-default-msvcrt=     - specifies msvc version the toolchain will target"
 	echo "                                 <msvcrt|msvcr80|msvcr90|msvcr100|msvcr110|msvcr120|ucrt>"
 	echo "    --rev=N                    - specifies number of the build revision"
@@ -165,6 +165,8 @@ readonly RUN_ARGS="$@"
 	echo "    gcc-11.2.0 (11.2.0 release)"
 	echo "    gcc-11.3.0 (11.3.0 release)"
 	echo "    gcc-11-branch (currently 11.4.0-prerelease)"
+	echo "    gcc-12.1.0 (12.1.0 release)"
+	echo "    gcc-12-branch (currently 12.2.0-prerelease)"
 	echo "    gcc-trunk (currently 12.0.0-snapshot)"
 
 	exit 0
@@ -308,6 +310,10 @@ while [[ $# > 0 ]]; do
 					RUNTIME_VERSION=v9
 					RUNTIME_BRANCH="v9.x"
 				;;
+				v10)
+					RUNTIME_VERSION=v10
+					RUNTIME_BRANCH="v10.x"
+				;;
 				trunk)
 					RUNTIME_VERSION=v9
 					RUNTIME_BRANCH="master"
@@ -338,6 +344,10 @@ while [[ $# > 0 ]]; do
 				;;
 				v9.0.0)
 					RUNTIME_VERSION=v9.0.0
+					RUNTIME_BRANCH="release"
+				;;
+				v10.0.0)
+					RUNTIME_VERSION=v10.0.0
 					RUNTIME_BRANCH="release"
 				;;
 				*)

--- a/patches/gcc/gcc-12-fix-for-windows-not-minding-non-existant-parent-dirs.patch
+++ b/patches/gcc/gcc-12-fix-for-windows-not-minding-non-existant-parent-dirs.patch
@@ -1,0 +1,111 @@
+--- a/libcpp/files.cc	2022-05-06 15:30:59.000000000 +0800
++++ b/libcpp/files.cc	2022-05-08 13:16:22.401550400 +0800
+@@ -30,6 +30,13 @@
+ #include "md5.h"
+ #include <dirent.h>
+ 
++/* Needed for stat_st_mode_symlink below */
++#if defined(_WIN32)
++#  include <windows.h>
++#  define S_IFLNK 0xF000
++#  define S_ISLNK(m) (((m) & S_IFMT) == S_IFLNK)
++#endif
++
+ /* Variable length record files on VMS will have a stat size that includes
+    record control characters that won't be included in the read size.  */
+ #ifdef VMS
+@@ -200,6 +207,49 @@
+ static int pchf_compare (const void *d_p, const void *e_p);
+ static bool check_file_against_entries (cpp_reader *, _cpp_file *, bool);
+ 
++#if defined(_WIN32)
++
++static int stat_st_mode_symlink (char const* path, struct stat* buf)
++{
++  WIN32_FILE_ATTRIBUTE_DATA attr;
++  memset(buf,0,sizeof(*buf));
++  int err = GetFileAttributesExA (path, GetFileExInfoStandard, &attr) ? 0 : 1;
++  if (!err)
++    {
++      WIN32_FIND_DATAA finddata;
++      HANDLE h = FindFirstFileA (path, &finddata);
++      if (h != INVALID_HANDLE_VALUE)
++        {
++          FindClose (h);
++          if ((finddata.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) &&
++              (finddata.dwReserved0 == IO_REPARSE_TAG_SYMLINK))
++              buf->st_mode = S_IFLNK;
++          else if (finddata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
++              buf->st_mode = S_IFDIR;
++          else if (finddata.dwFileAttributes & FILE_ATTRIBUTE_ARCHIVE)
++              buf->st_mode = S_IFDIR;
++          else
++              buf->st_mode = S_IFREG;
++          buf->st_mode |= S_IREAD;
++          if (!(finddata.dwFileAttributes & FILE_ATTRIBUTE_READONLY))
++              buf->st_mode |= S_IWRITE;
++        }
++      else
++        {
++          buf->st_mode = S_IFDIR;
++        }
++      return 0;
++    }
++  return -1;
++}
++
++#else
++
++#define stat_st_mode_symlink (_name, _buf) stat ((_name), (_buf))
++
++#endif
++
++
+ /* Given a filename in FILE->PATH, with the empty string interpreted
+    as <stdin>, open it.
+ 
+@@ -229,7 +279,44 @@
+     }
+   else
+     file->fd = open (file->path, O_RDONLY | O_NOCTTY | O_BINARY, 0666);
++#if defined(_WIN32) || defined(__CYGWIN__)
++  /* Windows and Posix differ in the face of paths of the form:
++     nonexistantdir/.. in that Posix will return ENOENT whereas
++     Windows won't care that we stepped into a non-existant dir
++     Only do these slow checks if ".." appears in file->path.
++     Cygwin also suffers from the same problem (but doesn't need
++     a new stat function):
++     http://cygwin.com/ml/cygwin/2013-05/msg00222.html
++  */
++  if (file->fd > 0)
++    {
++      char filepath[MAX_PATH];
++      strncpy (filepath, file->path, sizeof(filepath) - 1);
++      char* dirsep = &filepath[0];
++      while ( (dirsep = strchr (dirsep, '\\')) != NULL)
++        *dirsep = '/';
++      if (strstr(file->path, "/../"))
++	{
++	  dirsep = &filepath[0];
++	  char dirsepc;
++	  /* Check each directory in the chain. */
++	  while ( (dirsep = strpbrk (dirsep, "\\/")) != NULL)
++	    {
++	      dirsepc = *(++dirsep);
++	      *dirsep = '\0';
++	      if (stat_st_mode_symlink (filepath, &file->st) == -1)
++	        {
++	          *dirsep = dirsepc;
++	          close (file->fd);
++	          file->fd = -1;
++	          return false;
++	        }
++	      *dirsep++ = dirsepc;
++	    }
++	}
++    }
++#endif
+
+   if (file->fd != -1)
+     {
+       if (fstat (file->fd, &file->st) == 0)

--- a/patches/gcc/gcc-12-fix-mingw-pch.patch
+++ b/patches/gcc/gcc-12-fix-mingw-pch.patch
@@ -1,0 +1,40 @@
+--- gcc/config/i386/host-mingw32.cc	(revision 226150)
++++ gcc/config/i386/host-mingw32.cc	(working copy)
+@@ -42,9 +42,6 @@
+ 
+ static inline void w32_error(const char*, const char*, int, const char*);
+ 
+-/* FIXME: Is this big enough?  */
+-static const size_t pch_VA_max_size  = 128 * 1024 * 1024;
+-
+ /* Granularity for reserving address space.  */
+ static size_t va_granularity = 0x10000;
+ 
+@@ -86,9 +83,6 @@
+ mingw32_gt_pch_get_address (size_t size, int fd  ATTRIBUTE_UNUSED)
+ {
+   void* res;
+-  size = (size + va_granularity - 1) & ~(va_granularity - 1);
+-  if (size > pch_VA_max_size)
+-    return NULL;
+ 
+   /* FIXME: We let system determine base by setting first arg to NULL.
+      Allocating at top of available address space avoids unnecessary
+@@ -98,7 +92,7 @@
+      If we allocate at bottom we need to reserve the address as early
+      as possible and at the same point in each invocation. */
+  
+-  res = VirtualAlloc (NULL, pch_VA_max_size,
++  res = VirtualAlloc (NULL, size,
+ 		      MEM_RESERVE | MEM_TOP_DOWN,
+ 		      PAGE_NOACCESS);
+   if (!res)
+@@ -148,7 +142,7 @@
+ 
+   /* Offset must be also be a multiple of allocation granularity for
+      this to work.  We can't change the offset. */ 
+-  if ((offset & (va_granularity - 1)) != 0 || size > pch_VA_max_size)
++  if ((offset & (va_granularity - 1)) != 0)
+     return -1;
+ 
+ 

--- a/patches/gcc/gcc-12-ktietz-libgomp.patch
+++ b/patches/gcc/gcc-12-ktietz-libgomp.patch
@@ -1,0 +1,55 @@
+diff --git a/libgomp/team.c b/libgomp/team.c
+index cb6875d70..5c7ae0a17 100644
+--- a/libgomp/team.c
++++ b/libgomp/team.c
+@@ -181,7 +181,7 @@ gomp_new_team (unsigned nthreads)
+       team = gomp_aligned_alloc (__alignof (struct gomp_team),
+ 				 sizeof (*team) + nthreads * extra);
+ #else
+-      team = team_malloc (sizeof (*team) + nthreads * extra);
++      team = gomp_malloc_cleared (sizeof (*team) + nthreads * extra);
+ #endif
+ 
+ #ifndef HAVE_SYNC_BUILTINS
+@@ -1114,7 +1114,7 @@ struct gomp_task_icv *
+ gomp_new_icv (void)
+ {
+   struct gomp_thread *thr = gomp_thread ();
+-  struct gomp_task *task = gomp_malloc (sizeof (struct gomp_task));
++  struct gomp_task *task = gomp_malloc_cleared (sizeof (struct gomp_task));
+   gomp_init_task (task, NULL, &gomp_global_icv);
+   thr->task = task;
+ #ifdef LIBGOMP_USE_PTHREADS
+diff --git a/libgomp/testsuite/config/default.exp b/libgomp/testsuite/config/default.exp
+index 7ac3f31d1..d4c6b85f7 100644
+--- a/libgomp/testsuite/config/default.exp
++++ b/libgomp/testsuite/config/default.exp
+@@ -15,3 +15,7 @@
+ # <http://www.gnu.org/licenses/>.
+ 
+ load_lib "standard.exp"
++
++# Support for old dejagnu.  Must be loaded here, not in libstdc++.exp, to
++# make sure all existing procs are loaded when their presence is tested.
++load_file $srcdir/../../gcc/testsuite/lib/dejapatches.exp
+diff --git a/libgomp/work.c b/libgomp/work.c
+index c53625afe..3b77bed7f 100644
+--- a/libgomp/work.c
++++ b/libgomp/work.c
+@@ -85,6 +85,7 @@ alloc_work_share (struct gomp_team *team)
+ #else
+   ws = gomp_malloc (team->work_share_chunk * sizeof (struct gomp_work_share));
+ #endif
++  memset (ws, 0, team->work_share_chunk * sizeof (struct gomp_work_share));
+   ws->next_alloc = team->work_shares[0].next_alloc;
+   team->work_shares[0].next_alloc = ws;
+   team->work_share_list_alloc = &ws[1];
+@@ -197,7 +198,7 @@ gomp_work_share_start (size_t ordered)
+       ws = gomp_aligned_alloc (__alignof (struct gomp_work_share),
+ 			       sizeof (*ws));
+ #else
+-      ws = gomp_malloc (sizeof (*ws));
++      ws = gomp_malloc_cleared (sizeof (*ws));
+ #endif
+       gomp_init_work_share (ws, ordered, 1);
+       thr->ts.work_share = ws;

--- a/scripts/gcc-12-branch.sh
+++ b/scripts/gcc-12-branch.sh
@@ -1,0 +1,157 @@
+
+#
+# The BSD 3-Clause License. http://www.opensource.org/licenses/BSD-3-Clause
+#
+# This file is part of MinGW-W64(mingw-builds: https://github.com/niXman/mingw-builds) project.
+# Copyright (c) 2011-2021 by niXman (i dotty nixman doggy gmail dotty com)
+# Copyright (c) 2012-2015 by Alexpux (alexpux doggy gmail dotty com)
+# All rights reserved.
+#
+# Project: MinGW-W64 ( http://sourceforge.net/projects/mingw-w64/ )
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# - Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the distribution.
+# - Neither the name of the 'MinGW-W64' nor the names of its contributors may
+#     be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# **************************************************************************
+
+PKG_VERSION=12
+PKG_NAME=gcc-${PKG_VERSION}-branch
+PKG_DIR_NAME=gcc-${PKG_VERSION}-branch
+PKG_TYPE=git
+PKG_URLS=(
+	"git://gcc.gnu.org/git/gcc.git|branch:releases/gcc-$PKG_VERSION|repo:$PKG_TYPE|module:$PKG_DIR_NAME"
+)
+
+PKG_PRIORITY=main
+
+#
+
+PKG_PATCHES=(
+	gcc/gcc-4.7-stdthreads.patch
+	gcc/gcc-5.1-iconv.patch
+	gcc/gcc-4.8-libstdc++export.patch
+	gcc/gcc-12-fix-for-windows-not-minding-non-existant-parent-dirs.patch
+	gcc/gcc-4.8.2-windows-lrealpath-no-force-lowercase-nor-backslash.patch
+	gcc/gcc-4.9.1-enable-shared-gnat-implib.mingw.patch
+	gcc/gcc-5.1.0-make-xmmintrin-header-cplusplus-compatible.patch
+	gcc/gcc-12-fix-mingw-pch.patch
+	gcc/gcc-5-dwarf-regression.patch
+	gcc/gcc-5.1.0-fix-libatomic-building-for-threads=win32.patch
+	gcc/gcc-12-ktietz-libgomp.patch
+	gcc/gcc-libgomp-ftime64.patch
+	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
+	gcc/gcc-10-libgcc-ldflags.patch
+)
+
+#
+
+PKG_CONFIGURE_FLAGS=(
+	--host=$HOST
+	--build=$BUILD
+	--target=$TARGET
+	#
+	--prefix=$MINGWPREFIX
+	--with-sysroot=$PREFIX
+	#--with-gxx-include-dir=$MINGWPREFIX/$TARGET/include/c++
+	#
+	$LINK_TYPE_GCC
+	#
+	$( [[ $USE_MULTILIB == yes ]] \
+		&& echo "--enable-targets=all --enable-multilib" \
+		|| echo "--disable-multilib" \
+	)
+	$( [[ "$DISABLE_GCC_LTO" == yes ]] \
+		&& echo "--enable-languages=$ENABLE_LANGUAGES" \
+		|| echo "--enable-languages=$ENABLE_LANGUAGES,lto"
+	)
+	--enable-libstdcxx-time=yes
+	--enable-threads=$THREADS_MODEL
+	--enable-libgomp
+	--enable-libatomic
+	$( [[ "$MSVCRT_PHOBOS_OK" == yes && "$D_LANG_ENABLED" == yes ]] \
+		&& echo "--enable-libphobos"
+	)
+	$( [[ "$DISABLE_GCC_LTO" == yes ]] \
+		&& echo "--disable-lto" \
+		|| echo "--enable-lto"
+	)
+	--enable-graphite
+	--enable-checking=release
+	--enable-fully-dynamic-string
+	--enable-version-specific-runtime-libs
+	--enable-libstdcxx-filesystem-ts=yes
+	$( [[ $EXCEPTIONS_MODEL == dwarf ]] \
+		&& echo "--disable-sjlj-exceptions --with-dwarf2" \
+	)
+	$( [[ $EXCEPTIONS_MODEL == sjlj ]] \
+		&& echo "--enable-sjlj-exceptions" \
+	)
+	#
+	--disable-libstdcxx-pch
+	--disable-libstdcxx-debug
+	$( [[ $BOOTSTRAPING == yes ]] \
+		&& echo "--enable-bootstrap" \
+		|| echo "--disable-bootstrap" \
+	)
+	--disable-rpath
+	--disable-win32-registry
+	--disable-nls
+	--disable-werror
+	--disable-symvers
+	#
+	--with-gnu-as
+	--with-gnu-ld
+	#
+	$PROCESSOR_OPTIMIZATION
+	$PROCESSOR_TUNE
+	#
+	--with-libiconv
+	--with-system-zlib
+	--with-{gmp,mpfr,mpc,isl}=$PREREQ_DIR/$HOST-$LINK_TYPE_SUFFIX
+	--with-pkgversion="\"$BUILD_ARCHITECTURE-$THREADS_MODEL-$EXCEPTIONS_MODEL${REV_STRING}, $MINGW_W64_PKG_STRING\""
+	--with-bugurl=$BUG_URL
+	#
+	CFLAGS="\"$COMMON_CFLAGS\""
+	CXXFLAGS="\"$COMMON_CXXFLAGS\""
+	CPPFLAGS="\"$COMMON_CPPFLAGS\""
+	LDFLAGS="\"$COMMON_LDFLAGS $( [[ $BUILD_ARCHITECTURE == i686 ]] && echo -Wl,--large-address-aware )\""
+	LD_FOR_TARGET=$PREFIX/bin/ld.exe
+)
+
+#
+
+PKG_MAKE_FLAGS=(
+	-j$JOBS
+	all
+)
+
+#
+
+PKG_INSTALL_FLAGS=(
+	-j1
+	DESTDIR=$BASE_BUILD_DIR
+	$( [[ $STRIP_ON_INSTALL == yes ]] && echo install-strip || echo install )
+)
+
+# **************************************************************************

--- a/scripts/gcc-12.1.0.sh
+++ b/scripts/gcc-12.1.0.sh
@@ -1,0 +1,152 @@
+
+#
+# The BSD 3-Clause License. http://www.opensource.org/licenses/BSD-3-Clause
+#
+# This file is part of MinGW-W64(mingw-builds: https://github.com/niXman/mingw-builds) project.
+# Copyright (c) 2011-2021 by niXman (i dotty nixman doggy gmail dotty com)
+# Copyright (c) 2012-2015 by Alexpux (alexpux doggy gmail dotty com)
+# All rights reserved.
+#
+# Project: MinGW-W64 ( http://sourceforge.net/projects/mingw-w64/ )
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# - Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the distribution.
+# - Neither the name of the 'MinGW-W64' nor the names of its contributors may
+#     be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# **************************************************************************
+
+PKG_VERSION=12.1.0
+PKG_NAME=gcc-${PKG_VERSION}
+PKG_DIR_NAME=gcc-${PKG_VERSION}
+PKG_TYPE=.tar.xz
+PKG_URLS=(
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}${PKG_TYPE}"
+)
+
+PKG_PRIORITY=main
+
+#
+
+PKG_PATCHES=(
+	gcc/gcc-4.7-stdthreads.patch
+	gcc/gcc-5.1-iconv.patch
+	gcc/gcc-4.8-libstdc++export.patch
+	gcc/gcc-12-fix-for-windows-not-minding-non-existant-parent-dirs.patch
+	gcc/gcc-4.8.2-windows-lrealpath-no-force-lowercase-nor-backslash.patch
+	gcc/gcc-4.9.1-enable-shared-gnat-implib.mingw.patch
+	gcc/gcc-5.1.0-make-xmmintrin-header-cplusplus-compatible.patch
+	gcc/gcc-12-fix-mingw-pch.patch
+	gcc/gcc-5-dwarf-regression.patch
+	gcc/gcc-5.1.0-fix-libatomic-building-for-threads=win32.patch
+	gcc/gcc-12-ktietz-libgomp.patch
+	gcc/gcc-libgomp-ftime64.patch
+	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
+	gcc/gcc-10-libgcc-ldflags.patch
+)
+
+#
+
+PKG_CONFIGURE_FLAGS=(
+	--host=$HOST
+	--build=$BUILD
+	--target=$TARGET
+	#
+	--prefix=$MINGWPREFIX
+	--with-sysroot=$PREFIX
+	#--with-gxx-include-dir=$MINGWPREFIX/$TARGET/include/c++
+	#
+	$LINK_TYPE_GCC
+	#
+	$( [[ $USE_MULTILIB == yes ]] \
+		&& echo "--enable-targets=all --enable-multilib" \
+		|| echo "--disable-multilib" \
+	)
+	--enable-languages=$ENABLE_LANGUAGES,lto
+	--enable-libstdcxx-time=yes
+	--enable-threads=$THREADS_MODEL
+	--enable-libgomp
+	--enable-libatomic
+	$( [[ "$MSVCRT_PHOBOS_OK" == yes && "$D_LANG_ENABLED" == yes ]] \
+		&& echo "--enable-libphobos"
+	)
+	--enable-lto
+	--enable-graphite
+	--enable-checking=release
+	--enable-fully-dynamic-string
+	--enable-version-specific-runtime-libs
+	--enable-libstdcxx-filesystem-ts=yes
+	$( [[ $EXCEPTIONS_MODEL == dwarf ]] \
+		&& echo "--disable-sjlj-exceptions --with-dwarf2" \
+	)
+	$( [[ $EXCEPTIONS_MODEL == sjlj ]] \
+		&& echo "--enable-sjlj-exceptions" \
+	)
+	#
+	--disable-libstdcxx-pch
+	--disable-libstdcxx-debug
+	$( [[ $BOOTSTRAPING == yes ]] \
+		&& echo "--enable-bootstrap" \
+		|| echo "--disable-bootstrap" \
+	)
+	--disable-rpath
+	--disable-win32-registry
+	--disable-nls
+	--disable-werror
+	--disable-symvers
+	#
+	--with-gnu-as
+	--with-gnu-ld
+	#
+	$PROCESSOR_OPTIMIZATION
+	$PROCESSOR_TUNE
+	#
+	--with-libiconv
+	--with-system-zlib
+	--with-{gmp,mpfr,mpc,isl}=$PREREQ_DIR/$HOST-$LINK_TYPE_SUFFIX
+	--with-pkgversion="\"$BUILD_ARCHITECTURE-$THREADS_MODEL-$EXCEPTIONS_MODEL${REV_STRING}, $MINGW_W64_PKG_STRING\""
+	--with-bugurl=$BUG_URL
+	#
+	CFLAGS="\"$COMMON_CFLAGS\""
+	CXXFLAGS="\"$COMMON_CXXFLAGS\""
+	CPPFLAGS="\"$COMMON_CPPFLAGS\""
+	LDFLAGS="\"$COMMON_LDFLAGS $( [[ $BUILD_ARCHITECTURE == i686 ]] && echo -Wl,--large-address-aware )\""
+	LD_FOR_TARGET=$PREFIX/bin/ld.exe
+	--with-boot-ldflags="\"$LDFLAGS -Wl,--disable-dynamicbase -static-libstdc++ -static-libgcc\""
+)
+
+#
+
+PKG_MAKE_FLAGS=(
+	-j$JOBS
+	all
+)
+
+#
+
+PKG_INSTALL_FLAGS=(
+	-j1
+	DESTDIR=$BASE_BUILD_DIR
+	$( [[ $STRIP_ON_INSTALL == yes ]] && echo install-strip || echo install )
+)
+
+# **************************************************************************

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -100,7 +100,7 @@ random_device_list=(
 )
 
 filesystem_list=(
-    "filesystem.cpp -std=c++11 -lstdc++fs -o filesystem.exe"
+    "filesystem.cpp -std=c++17 -o filesystem.exe"
 )
 
 # **************************************************************************
@@ -119,4 +119,4 @@ PKG_TESTS["lasterror_test2"]=lasterror_test2_list[@]
 PKG_TESTS["time_test"]=time_test_list[@]
 [[ $THREADS_MODEL == posix ]] && { PKG_TESTS["sleep_test"]=sleep_test_list[@]; }
 [[ `echo $BUILD_VERSION | cut -d. -f1` -ge 6 ]] && { PKG_TESTS["random_device"]=random_device_list[@]; }
-[[ `echo $BUILD_VERSION | cut -d. -f1` -ge 7 ]] && { PKG_TESTS["filesystem"]=filesystem_list[@]; }
+[[ `echo $BUILD_VERSION | cut -d. -f1` -ge 8 ]] && { PKG_TESTS["filesystem"]=filesystem_list[@]; }

--- a/tests/filesystem.cpp
+++ b/tests/filesystem.cpp
@@ -35,9 +35,9 @@
 // **************************************************************************
 
 #include <iostream>
-#include <experimental/filesystem>
+#include <filesystem>
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 void demo_status(const fs::file_status s) {
     if(fs::is_regular_file(s)) std::cout << " is a regular file\n";


### PR DESCRIPTION
- Update some patch files for GCC 12.
- Update `filesystem` test from `<experimental/filesystem>` to C++17 standard `<filesystem>` header. The former one no longer work (will throw an exception).
- I've tried updating GitHub Actions workflow, but some uncommon error occurred while building with sjlj (see [here](https://github.com/Guyutongxue/mingw-builds/actions/runs/2299141703)). So I revert this change.