### PR TITLE
CI: build new version

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -12,43 +12,43 @@ jobs:
         config:
         - {
             name: "x86_64 posix sjlj",
-            artifact: "x86_64-11.2.0-release-posix-sjlj-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            artifact: "x86_64-12.1.0-release-posix-sjlj-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "x86_64 posix seh",
-            artifact: "x86_64-11.2.0-release-posix-seh-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            artifact: "x86_64-12.1.0-release-posix-seh-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "x86_64 win32 sjlj",
-            artifact: "x86_64-11.2.0-release-win32-sjlj-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            artifact: "x86_64-12.1.0-release-win32-sjlj-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "x86_64 win32 seh",
-            artifact: "x86_64-11.2.0-release-win32-seh-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            artifact: "x86_64-12.1.0-release-win32-seh-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "i686 posix sjlj",
-            artifact: "i686-11.2.0-release-posix-sjlj-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
+            artifact: "i686-12.1.0-release-posix-sjlj-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "i686 posix dwarf",
-            artifact: "i686-11.2.0-release-posix-dwarf-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
+            artifact: "i686-12.1.0-release-posix-dwarf-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "i686 win32 sjlj",
-            artifact: "i686-11.2.0-release-win32-sjlj-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
+            artifact: "i686-12.1.0-release-win32-sjlj-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
           }
         - {
             name: "i686 win32 dwarf",
-            artifact: "i686-11.2.0-release-win32-dwarf-rt_v9-rev0.7z",
-            build_cmd: "--mode=gcc-11.2.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v9 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
+            artifact: "i686-12.1.0-release-win32-dwarf-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
           }
 
     steps:
@@ -104,35 +104,35 @@ jobs:
         config:
         - {
             name: "x86_64 posix sjlj",
-            artifact: "x86_64-11.2.0-release-posix-sjlj-rt_v9-rev0.7z"
+            artifact: "x86_64-12.1.0-release-posix-sjlj-rt_v10-rev0.7z"
           }
         - {
             name: "x86_64 posix seh",
-            artifact: "x86_64-11.2.0-release-posix-seh-rt_v9-rev0.7z"
+            artifact: "x86_64-12.1.0-release-posix-seh-rt_v10-rev0.7z"
           }
         - {
             name: "x86_64 win32 sjlj",
-            artifact: "x86_64-11.2.0-release-win32-sjlj-rt_v9-rev0.7z"
+            artifact: "x86_64-12.1.0-release-win32-sjlj-rt_v10-rev0.7z"
           }
         - {
             name: "x86_64 win32 seh",
-            artifact: "x86_64-11.2.0-release-win32-seh-rt_v9-rev0.7z"
+            artifact: "x86_64-12.1.0-release-win32-seh-rt_v10-rev0.7z"
           }
         - {
             name: "i686 posix sjlj",
-            artifact: "i686-11.2.0-release-posix-sjlj-rt_v9-rev0.7z"
+            artifact: "i686-12.1.0-release-posix-sjlj-rt_v10-rev0.7z"
           }
         - {
             name: "i686 posix dwarf",
-            artifact: "i686-11.2.0-release-posix-dwarf-rt_v9-rev0.7z"
+            artifact: "i686-12.1.0-release-posix-dwarf-rt_v10-rev0.7z"
           }
         - {
             name: "i686 win32 sjlj",
-            artifact: "i686-11.2.0-release-win32-sjlj-rt_v9-rev0.7z"
+            artifact: "i686-12.1.0-release-win32-sjlj-rt_v10-rev0.7z"
           }
         - {
             name: "i686 win32 dwarf",
-            artifact: "i686-11.2.0-release-win32-dwarf-rt_v9-rev0.7z"
+            artifact: "i686-12.1.0-release-win32-dwarf-rt_v10-rev0.7z"
           }
 
     needs: release


### PR DESCRIPTION
gcc 11.2.0 with rt v10

I expect this to fail, because all the SJLJ builds failed on https://github.com/niXman/mingw-builds-binaries/actions/runs/2404990488