### PR TITLE
GitHub Actions: Enabled ntfs compression for build directory

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -58,6 +58,12 @@ jobs:
       with:
         update: true
 
+    - name: Compress working directory
+      shell: msys2 {0}
+      run: |
+        export MSYS2_ARG_CONV_EXCL=*
+        compact /c /s:`pwd -W`
+
     - name: Build
       shell: msys2 {0}
       run: ./build ${{ matrix.config.build_cmd }}


### PR DESCRIPTION
This way the sjlj builds would not run out of disk space