### PR TITLE
GitHub Actions: Use C drive for buildroot

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -13,42 +13,42 @@ jobs:
         - {
             name: "x86_64 posix sjlj",
             artifact: "x86_64-12.1.0-release-posix-sjlj-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran"
           }
         - {
             name: "x86_64 posix seh",
             artifact: "x86_64-12.1.0-release-posix-seh-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran"
           }
         - {
             name: "x86_64 win32 sjlj",
             artifact: "x86_64-12.1.0-release-win32-sjlj-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=sjlj --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran"
           }
         - {
             name: "x86_64 win32 seh",
             artifact: "x86_64-12.1.0-release-win32-seh-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++"
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran"
           }
         - {
             name: "i686 posix sjlj",
             artifact: "i686-12.1.0-release-posix-sjlj-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++,fortran"
           }
         - {
             name: "i686 posix dwarf",
             artifact: "i686-12.1.0-release-posix-dwarf-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran"
           }
         - {
             name: "i686 win32 sjlj",
             artifact: "i686-12.1.0-release-win32-sjlj-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++"
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=sjlj --arch=i686 --bin-compress --enable-languages=c,c++,fortran"
           }
         - {
             name: "i686 win32 dwarf",
             artifact: "i686-12.1.0-release-win32-dwarf-rt_v10-rev0.7z",
-            build_cmd: "--mode=gcc-12.1.0 --buildroot=buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++"
+            build_cmd: "--mode=gcc-12.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran"
           }
 
     steps:
@@ -65,7 +65,7 @@ jobs:
     - name: Upload
       uses: actions/upload-artifact@v1
       with:
-        path: ./buildroot/archives/${{ matrix.config.artifact }}
+        path: c:/buildroot/archives/${{ matrix.config.artifact }}
         name: ${{ matrix.config.artifact }}
 
   release:


### PR DESCRIPTION
D drive has 12GB, whereas C drive has more space.

As seen at https://github.com/cristianadam/mingw-builds/actions/runs/2411618463 it almost made it, the failure was no longer due to lack of disk space, but of the lack of time.