### PR TITLE
Fixes GH-1

### DIFF
--- a/patches/gcc/fix-gcc-8-branch-Backport-patches-for-std-filesystem-from-master.patch
+++ b/patches/gcc/fix-gcc-8-branch-Backport-patches-for-std-filesystem-from-master.patch
@@ -1,0 +1,28 @@
+diff -Nuarp gcc-8.5.0/libstdc++-v3/src/filesystem/std-ops.cc gcc-8.5.0.b/libstdc++-v3/src/filesystem/std-ops.cc
+--- gcc-8.5.0/libstdc++-v3/src/filesystem/std-ops.cc	2022-06-17 01:13:32.137484100 -0400
++++ gcc-8.5.0.b/libstdc++-v3/src/filesystem/std-ops.cc	2022-06-16 18:29:56.009348200 -0400
+@@ -1563,7 +1563,7 @@ fs::path fs::temp_directory_path()
+ {
+   error_code ec;
+   path tmp = temp_directory_path(ec);
+-  if (ec)
++  if (ec.value())
+     _GLIBCXX_THROW_OR_ABORT(filesystem_error("temp_directory_path", ec));
+   return tmp;
+ }
+@@ -1593,7 +1593,6 @@ fs::path fs::temp_directory_path(error_c
+   for (auto e = env; tmpdir == nullptr && *e != nullptr; ++e)
+     tmpdir = ::getenv(*e);
+   p = tmpdir ? tmpdir : "/tmp";
+-#endif
+   auto st = status(p, ec);
+   if (ec)
+     p.clear();
+@@ -1602,6 +1601,7 @@ fs::path fs::temp_directory_path(error_c
+       p.clear();
+       ec = std::make_error_code(std::errc::not_a_directory);
+     }
++#endif
+   return p;
+ }
+ 

--- a/scripts/gcc-8.5.0.sh
+++ b/scripts/gcc-8.5.0.sh
@@ -61,6 +61,7 @@ PKG_PATCHES=(
 	gcc/gcc-6-ktietz-libgomp.patch
 	gcc/gcc-libgomp-ftime64.patch
 	gcc/gcc-8-branch-Backport-patches-for-std-filesystem-from-master.patch
+	gcc/fix-gcc-8-branch-Backport-patches-for-std-filesystem-from-master.patch
 	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
 	gcc/gcc-8.5.0-r11-702-gcc-bz67275-git-c83027f32d9cca84959c7d6a1e519a0129731501.patch
 )


### PR DESCRIPTION
- the filesystem.cpp test case was failing for i686 builds. tested this patch with both sjlj and dwarf builds of GCC 8.5.0 w/v9 mingw-w64.

The i686 GCC 8.5.0 build was failing it's filesystem.cpp test execution. I don't know why or have an explanation for why it succeeds on x86_64.

My issue:
https://github.com/rallenh/mingw-builds/issues/1

Tested builds:
x86_64 SEH
x86_64 SJLJ
i686 DWARF
i686 SJLJ