### PR TITLE
Ucrt tweaks

### DIFF
--- a/scripts/make.sh
+++ b/scripts/make.sh
@@ -43,7 +43,10 @@ PKG_URLS=(
 	"https://ftp.gnu.org/gnu/make/make-${PKG_VERSION}${PKG_TYPE}"
 )
 
-PKG_PRIORITY=extra
+#
+
+# needed when building ucrt bootstraps; mingw-builds requires mingw32-make.exe
+PKG_PRIORITY=main
 
 #
 

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -81,8 +81,14 @@ lasterror_test2_list=(
 	"lasterror_test2.cpp -o lasterror_test2.exe"
 )
 
-time_test_list=(
-	"time_test.c -lpthread -o time_test.exe"
+[[ $MSVCRT_VERSION == ucrt ]] && (
+	time_test_list=(
+		"time_test.c -lpthread -lucrt -o time_test.exe"
+	)
+) || (
+	time_test_list=(
+		"time_test.c -lpthread -o time_test.exe"
+	)
 )
 
 [[ `echo $BUILD_VERSION | cut -d. -f1` == 4 && `echo $BUILD_VERSION | cut -d. -f2` -le 6 ]] && (

--- a/scripts/winpthreads.sh
+++ b/scripts/winpthreads.sh
@@ -61,6 +61,10 @@ PKG_CONFIGURE_FLAGS=(
 	--enable-shared
 	--enable-static
 	#
+	$( [[ $MSVCRT_VERSION == ucrt ]] && \
+		[[ $BOOTSTRAPING == no ]] && \
+			[[ $RUNTIME_MAJOR_VERSION -ge 10 ]] && \
+				echo "LIBS=\"-lucrtbase\"" )
 	CFLAGS="\"$COMMON_CFLAGS\""
 	CXXFLAGS="\"$COMMON_CXXFLAGS\""
 	CPPFLAGS="\"$COMMON_CPPFLAGS\""


### PR DESCRIPTION
These are the changes needed to overcome the issues mentioned in the ticket for UCRT support for mingw-builds.

I have successfully built UCRT bootstrapper(s) for GCC 10.4.0/11.3.0/12.1.0 (both arches). I was also able to build full mingw-builds (e.g. extras) with the bootstrapper(s) for GCC 10.4.0/11.3.0/12.1.0 (both arches)