### PR TITLE
another UCRT tweak

### DIFF
--- a/scripts/winpthreads.sh
+++ b/scripts/winpthreads.sh
@@ -61,10 +61,17 @@ PKG_CONFIGURE_FLAGS=(
 	--enable-shared
 	--enable-static
 	#
+    # this linkage is only needed on the initial bootstrap of a ucrt mingw-build
+    # build using a non-ucrt toolchain, such as a mingw-builds gcc msvcrt (the default).
+    # when using the --provided-toolchain option (intended to be used with ucrt
+    # mingw-builds) with a first/initial bootstrap build of a toolchain with ucrt,
+    # this linkage isn't needed then either. so assume the first ucrt mingw-build
+    # toolchain would be built with a "--rev=0" arg.
 	$( [[ $MSVCRT_VERSION == ucrt ]] && \
 		[[ $BOOTSTRAPING == no ]] && \
 			[[ $RUNTIME_MAJOR_VERSION -ge 10 ]] && \
-				echo "LIBS=\"-lucrtbase\"" )
+                [[ $REV_NUM -eq 0 ]] && \
+                    echo "LIBS=\"-lucrtbase\"" )
 	CFLAGS="\"$COMMON_CFLAGS\""
 	CXXFLAGS="\"$COMMON_CXXFLAGS\""
 	CPPFLAGS="\"$COMMON_CPPFLAGS\""


### PR DESCRIPTION
- need to add another check condition so that multiple bootstrap builds can be be built successfully. bootstrap builds can then be used to build full (--extras) mingw-builds. a full build could be used to build more bull builds (how it's done today).