### PR TITLE
Update expat to 2.4.9

### DIFF
--- a/scripts/expat.sh
+++ b/scripts/expat.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=2.4.7
+PKG_VERSION=2.4.9
 PKG_NAME=expat-${PKG_VERSION}
 PKG_DIR_NAME=expat-${PKG_VERSION}
 PKG_TYPE=.tar.xz


### PR DESCRIPTION
Expat 2.4.7 has been removed from sourceforge because of security vulnerability.