### PR TITLE
zlib: use GitHub URL for fetching

### DIFF
--- a/scripts/zlib.sh
+++ b/scripts/zlib.sh
@@ -40,7 +40,7 @@ PKG_NAME=$PKG_ARCHITECTURE-zlib-${PKG_VERSION}-$LINK_TYPE_SUFFIX
 PKG_DIR_NAME=zlib-${PKG_VERSION}
 PKG_TYPE=.tar.gz
 PKG_URLS=(
-	"https://zlib.net/current/zlib-${PKG_VERSION}${PKG_TYPE}"
+	"https://github.com/madler/zlib/archive/refs/tags/v${PKG_VERSION}${PKG_TYPE}"
 )
 
 PKG_PRIORITY=prereq


### PR DESCRIPTION
Since zlib.net does not provide older releases, this will make sure that the script can still pull older zlib releases in case zlib.net is updated and this repo is still behind.

The GitHub links are the same since 2011 with v0.8.

This conflicts with #619. I have no preference which gets merged first.