### PR TITLE
New option to set default windows version the built toolchain will target

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ In order to use the scripts provided by the MinGW-W64 project it is needed:
   --threads=<posix|win32>             - used threads model.
   --enable-languages=<langs>          - comma separated list(without spaces) of gcc supported languages.
                                         available languages: ada,c,c++,fortran,objc,obj-c++
+  --with-default-win32-winnt=<ver>    - default windows version the toolchain will target
 ```
   For more options run: "./build --help"
 

--- a/build
+++ b/build
@@ -73,6 +73,7 @@ readonly RUN_ARGS="$@"
 	echo "                                 v3.3.0, v4.0.6, v5.0.4, v6.0.0, v7.0.0, v8.0.2, v9.0.0, v10.0.0 is a specific release versions, uses the tarball"
 	echo "    --with-default-msvcrt=     - specifies msvc version the toolchain will target"
 	echo "                                 <msvcrt|msvcr80|msvcr90|msvcr100|msvcr110|msvcr120|ucrt>"
+	echo "    --with-default-win32-winnt=<ver>     - specifies default windows version the toolchain will target"
 	echo "    --rev=N                    - specifies number of the build revision"
 	echo "    --threads=<model>          - specifies the threads model for GCC/libstdc++"
 	echo "                                 available: win32, posix"
@@ -366,6 +367,7 @@ while [[ $# > 0 ]]; do
 				;;
 			esac
 		;;
+		--with-default-win32-winnt=*) WIN32_WINNT_VERSION=${1/--with-default-win32-winnt=/} ;;
 		--threads=*)
 			THREADS_MODEL=${1/--threads=/}
 			case $THREADS_MODEL in

--- a/scripts/mingw-w64-api.sh
+++ b/scripts/mingw-w64-api.sh
@@ -66,6 +66,9 @@ PKG_CONFIGURE_FLAGS=(
 	#
 	--enable-sdk=all
 	--enable-secure-api
+	$( [[ -n "$WIN32_WINNT_VERSION" ]] \
+		&& echo "--with-default-win32-winnt=$WIN32_WINNT_VERSION"
+	)
 	$( [[ -n "$MSVCRT_VERSION" ]] \
 		&& echo "--with-default-msvcrt=$MSVCRT_VERSION"
 	)


### PR DESCRIPTION
This PR adds `--with-default-win32-winnt` option to set a default value for `_WIN32_WINNT` macro.

This value will be passed to the configure script of mingw-w64 headers and sets the windows version the built toolchain will target by default. For example, if you want to build a toolchain that targets Windows 7, you can pass `--with-default-win32-winnt=0x0601` option.