### PR TITLE
Update binutils to 2.39

### DIFF
--- a/patches/binutils/0110-binutils-mingw-gnu-print.patch
+++ b/patches/binutils/0110-binutils-mingw-gnu-print.patch
@@ -1,27 +1,3 @@
-diff -urN binutils-2.38.orig/bfd/bfd-in.h binutils-2.38/bfd/bfd-in.h
---- binutils-2.38.orig/bfd/bfd-in.h	2022-01-22 13:14:07.000000000 +0100
-+++ binutils-2.38/bfd/bfd-in.h	2022-04-01 16:18:40.062376800 +0200
-@@ -123,7 +123,7 @@
- 
- #if BFD_HOST_64BIT_LONG
- #define BFD_VMA_FMT "l"
--#elif defined (__MSVCRT__)
-+#elif defined(__MSVCRT__) && !defined( __USE_MINGW_ANSI_STDIO)
- #define BFD_VMA_FMT "I64"
- #else
- #define BFD_VMA_FMT "ll"
-diff -urN binutils-2.38.orig/bfd/bfd-in2.h binutils-2.38/bfd/bfd-in2.h
---- binutils-2.38.orig/bfd/bfd-in2.h	2022-01-22 13:14:07.000000000 +0100
-+++ binutils-2.38/bfd/bfd-in2.h	2022-04-01 16:19:30.593721500 +0200
-@@ -130,7 +130,7 @@
- 
- #if BFD_HOST_64BIT_LONG
- #define BFD_VMA_FMT "l"
--#elif defined (__MSVCRT__)
-+#elif defined(__MSVCRT__) && !defined(__USE_MINGW_ANSI_STDIO)
- #define BFD_VMA_FMT "I64"
- #else
- #define BFD_VMA_FMT "ll"
 diff -urN binutils-2.38.orig/binutils/dwarf.c binutils-2.38/binutils/dwarf.c
 --- binutils-2.38.orig/binutils/dwarf.c	2022-01-22 13:14:07.000000000 +0100
 +++ binutils-2.38/binutils/dwarf.c	2022-04-01 16:20:13.920951900 +0200
@@ -34,30 +10,6 @@ diff -urN binutils-2.38.orig/binutils/dwarf.c binutils-2.38/binutils/dwarf.c
  #  define DWARF_VMA_FMT		"ll"
  #  define DWARF_VMA_FMT_LONG	"%16.16llx"
  # else
-diff -urN binutils-2.38.orig/binutils/nm.c binutils-2.38/binutils/nm.c
---- binutils-2.38.orig/binutils/nm.c	2022-01-22 13:14:07.000000000 +0100
-+++ binutils-2.38/binutils/nm.c	2022-04-01 16:21:05.889862000 +0200
-@@ -1556,7 +1556,7 @@
- #if BFD_HOST_64BIT_LONG
-       ;
- #elif BFD_HOST_64BIT_LONG_LONG
--#ifndef __MSVCRT__
-+#if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)
-       length = "ll";
- #else
-       length = "I64";
-diff -urN binutils-2.38.orig/binutils/prdbg.c binutils-2.38/binutils/prdbg.c
---- binutils-2.38.orig/binutils/prdbg.c	2022-01-22 13:14:07.000000000 +0100
-+++ binutils-2.38/binutils/prdbg.c	2022-04-01 16:21:51.875019800 +0200
-@@ -497,7 +497,7 @@
- #if BFD_HOST_64BIT_LONG_LONG
-   else if (sizeof (vma) <= sizeof (unsigned long long))
-     {
--#ifndef __MSVCRT__
-+#if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)
-       if (hexp)
- 	sprintf (buf, "0x%llx", (unsigned long long) vma);
-       else if (unsignedp)
 diff -urN binutils-2.38.orig/binutils/strings.c binutils-2.38/binutils/strings.c
 --- binutils-2.38.orig/binutils/strings.c	2022-01-22 13:14:07.000000000 +0100
 +++ binutils-2.38/binutils/strings.c	2022-04-01 16:23:19.687330400 +0200

--- a/scripts/binutils.sh
+++ b/scripts/binutils.sh
@@ -35,7 +35,7 @@
 
 # **************************************************************************
 
-PKG_VERSION=2.38
+PKG_VERSION=2.39
 PKG_NAME=binutils-${PKG_VERSION}
 [[ $USE_MULTILIB == yes ]] && {
 	PKG_NAME=$BUILD_ARCHITECTURE-$PKG_NAME-multi


### PR DESCRIPTION
This should fix [the concurrency bug in dlltool](https://sourceware.org/bugzilla/show_bug.cgi?id=28885) that caused random failure when building mingw-w64-crt.

See also #614.
