### PR TITLE
build: use eval to allow for tilde expansion

### DIFF
--- a/build
+++ b/build
@@ -52,7 +52,7 @@ readonly RUN_ARGS="$@"
 	echo "usage:"
 	echo "  ./${0##*/} --mode=[clang|gcc|python]-version --arch=<i686|x86_64> [OPTIONS]"
 	echo "  help:"
-	echo "    --buildroot=<path>         - specifies the build root directory"
+	echo "    --buildroot=<path>         - specifies the build root directory (path without spaces)"
 	echo "    --fetch-only               - download sources without building"
 	echo "    --patch-on-fetch           - patch sources when fetching them"
 	echo "    --update-sources           - try to update sources from repositories before build"
@@ -226,6 +226,7 @@ while [[ $# > 0 ]]; do
 			ROOT_DIR=${1/--buildroot=/}
 			ROOT_DIR=${ROOT_DIR//:/:\/}
 			ROOT_DIR=${ROOT_DIR//\/\//\/}
+			ROOT_DIR="$(eval cd ${ROOT_DIR} && pwd -P)"
 			mkdir -p ${ROOT_DIR} || die "incorrect buildroot directory: \"${ROOT_DIR}\". terminate."
 			pushd ${ROOT_DIR} > /dev/null
 			ROOT_DIR=$PWD


### PR DESCRIPTION
Paths with spaces don't work, however. Document this.

Fixes #618.