### PR TITLE
Download new toolchains from GitHub releases

### DIFF
--- a/library/config-win.sh
+++ b/library/config-win.sh
@@ -35,11 +35,11 @@
 
 # **************************************************************************
 
-readonly HOST_MINGW_VERSION=8.1.0
-readonly HOST_MINGW_RT_VERSION=6
-readonly HOST_MINGW_BUILD_REV=0
-readonly i686_HOST_MINGW_PATH_URL="https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/$HOST_MINGW_VERSION/threads-posix/{exceptions}/i686-$HOST_MINGW_VERSION-release-posix-{exceptions}-rt_v$HOST_MINGW_RT_VERSION-rev$HOST_MINGW_BUILD_REV.7z"
-readonly x86_64_HOST_MINGW_PATH_URL="https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/$HOST_MINGW_VERSION/threads-posix/{exceptions}/x86_64-$HOST_MINGW_VERSION-release-posix-{exceptions}-rt_v$HOST_MINGW_RT_VERSION-rev$HOST_MINGW_BUILD_REV.7z"
+readonly HOST_MINGW_VERSION=12.2.0
+readonly HOST_MINGW_RT_VERSION=10
+readonly HOST_MINGW_BUILD_REV=1
+readonly i686_HOST_MINGW_PATH_URL="https://github.com/niXman/mingw-builds-binaries/releases/download/$HOST_MINGW_VERSION-rt_v$HOST_MINGW_RT_VERSION-rev$HOST_MINGW_BUILD_REV/i686-$HOST_MINGW_VERSION-release-posix-{exceptions}-rt_v$HOST_MINGW_RT_VERSION-rev$HOST_MINGW_BUILD_REV.7z"
+readonly x86_64_HOST_MINGW_PATH_URL="https://github.com/niXman/mingw-builds-binaries/releases/download/$HOST_MINGW_VERSION-rt_v$HOST_MINGW_RT_VERSION-rev$HOST_MINGW_BUILD_REV/x86_64-$HOST_MINGW_VERSION-release-posix-{exceptions}-rt_v$HOST_MINGW_RT_VERSION-rev$HOST_MINGW_BUILD_REV.7z"
 
 # **************************************************************************
 


### PR DESCRIPTION
If `--provided-toolchain` is not specified, download GCC 12.2.0 from GitHub instead of GCC 8.1.0 from SourceForge.

This change breaks `--exceptions=sjlj` because the latest release on GitHub lacks sjlj toolchains. I'll leave it broken because sjlj is obsolete anyway and I don't know if it's safe to build sjlj toolchains with dwarf/seh ones. Those who want to build sjlj toolchains should manually install sjlj toolchains and specify `--provided-toolchain` option.