### PR TITLE
Update host toolchain & add UCRT to build matrix

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -11,24 +11,44 @@ jobs:
       matrix:
         config:
         - {
-            name: "x86_64 posix seh",
+            name: "x86_64 posix seh msvcrt",
             artifact: "x86_64-12.2.0-release-posix-seh-msvcrt-rt_v10-rev0.7z",
             build_cmd: "--mode=gcc-12.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran"
           }
         - {
-            name: "x86_64 win32 seh",
+            name: "x86_64 posix seh ucrt",
+            artifact: "x86_64-12.2.0-release-posix-seh-ucrt-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt"
+          }
+        - {
+            name: "x86_64 win32 seh msvcrt",
             artifact: "x86_64-12.2.0-release-win32-seh-msvcrt-rt_v10-rev0.7z",
             build_cmd: "--mode=gcc-12.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran"
           }
         - {
-            name: "i686 posix dwarf",
+            name: "x86_64 win32 seh ucrt",
+            artifact: "x86_64-12.2.0-release-win32-seh-ucrt-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt"
+          }
+        - {
+            name: "i686 posix dwarf msvcrt",
             artifact: "i686-12.2.0-release-posix-dwarf-msvcrt-rt_v10-rev0.7z",
             build_cmd: "--mode=gcc-12.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran"
           }
         - {
-            name: "i686 win32 dwarf",
+            name: "i686 posix dwarf ucrt",
+            artifact: "i686-12.2.0-release-posix-dwarf-ucrt-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt"
+          }
+        - {
+            name: "i686 win32 dwarf msvcrt",
             artifact: "i686-12.2.0-release-win32-dwarf-msvcrt-rt_v10-rev0.7z",
             build_cmd: "--mode=gcc-12.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran"
+          }
+        - {
+            name: "i686 win32 dwarf ucrt",
+            artifact: "i686-12.2.0-release-win32-dwarf-ucrt-rt_v10-rev0.7z",
+            build_cmd: "--mode=gcc-12.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v10 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt"
           }
 
     steps:
@@ -83,20 +103,36 @@ jobs:
       matrix:
         config:
         - {
-            name: "x86_64 posix seh",
+            name: "x86_64 posix seh msvcrt",
             artifact: "x86_64-12.2.0-release-posix-seh-msvcrt-rt_v10-rev0.7z"
           }
         - {
-            name: "x86_64 win32 seh",
+            name: "x86_64 posix seh ucrt",
+            artifact: "x86_64-12.2.0-release-posix-seh-ucrt-rt_v10-rev0.7z"
+          }
+        - {
+            name: "x86_64 win32 seh msvcrt",
             artifact: "x86_64-12.2.0-release-win32-seh-msvcrt-rt_v10-rev0.7z"
           }
         - {
-            name: "i686 posix dwarf",
+            name: "x86_64 win32 seh ucrt",
+            artifact: "x86_64-12.2.0-release-win32-seh-ucrt-rt_v10-rev0.7z"
+          }
+        - {
+            name: "i686 posix dwarf msvcrt",
             artifact: "i686-12.2.0-release-posix-dwarf-msvcrt-rt_v10-rev0.7z"
           }
         - {
-            name: "i686 win32 dwarf",
+            name: "i686 posix dwarf ucrt",
+            artifact: "i686-12.2.0-release-posix-dwarf-ucrt-rt_v10-rev0.7z"
+          }
+        - {
+            name: "i686 win32 dwarf msvcrt",
             artifact: "i686-12.2.0-release-win32-dwarf-msvcrt-rt_v10-rev0.7z"
+          }
+        - {
+            name: "i686 win32 dwarf ucrt",
+            artifact: "i686-12.2.0-release-win32-dwarf-ucrt-rt_v10-rev0.7z"
           }
 
     needs: release

--- a/build
+++ b/build
@@ -546,8 +546,8 @@ if [[ -z "$PROVIDED_TOOLCHAIN" ]] ; then
 		$TOOLCHAINS_DIR \
 		$i686_HOST_MINGW_PATH \
 		$x86_64_HOST_MINGW_PATH \
-		${i686_HOST_MINGW_PATH_URL//"{exceptions}"/$EXCEPTIONS_MODEL_I686} \
-		${x86_64_HOST_MINGW_PATH_URL//"{exceptions}"/$EXCEPTIONS_MODEL_X86_64}
+		$(echo $i686_HOST_MINGW_PATH_URL | sed "s/{exceptions}/$EXCEPTIONS_MODEL_I686/g; s/{msvcrt}/$MSVCRT_VERSION/g") \
+		$(echo $x86_64_HOST_MINGW_PATH_URL | sed "s/{exceptions}/$EXCEPTIONS_MODEL_X86_64/g; s/{msvcrt}/$MSVCRT_VERSION/g")
 fi
 
 # **************************************************************************

--- a/library/config-win.sh
+++ b/library/config-win.sh
@@ -37,9 +37,9 @@
 
 readonly HOST_MINGW_VERSION=12.2.0
 readonly HOST_MINGW_RT_VERSION=10
-readonly HOST_MINGW_BUILD_REV=1
-readonly i686_HOST_MINGW_PATH_URL="https://github.com/niXman/mingw-builds-binaries/releases/download/$HOST_MINGW_VERSION-rt_v$HOST_MINGW_RT_VERSION-rev$HOST_MINGW_BUILD_REV/i686-$HOST_MINGW_VERSION-release-posix-{exceptions}-rt_v$HOST_MINGW_RT_VERSION-rev$HOST_MINGW_BUILD_REV.7z"
-readonly x86_64_HOST_MINGW_PATH_URL="https://github.com/niXman/mingw-builds-binaries/releases/download/$HOST_MINGW_VERSION-rt_v$HOST_MINGW_RT_VERSION-rev$HOST_MINGW_BUILD_REV/x86_64-$HOST_MINGW_VERSION-release-posix-{exceptions}-rt_v$HOST_MINGW_RT_VERSION-rev$HOST_MINGW_BUILD_REV.7z"
+readonly HOST_MINGW_BUILD_REV=2
+readonly i686_HOST_MINGW_PATH_URL="https://github.com/niXman/mingw-builds-binaries/releases/download/$HOST_MINGW_VERSION-rt_v$HOST_MINGW_RT_VERSION-rev$HOST_MINGW_BUILD_REV/i686-$HOST_MINGW_VERSION-release-posix-{exceptions}-{msvcrt}-rt_v$HOST_MINGW_RT_VERSION-rev$HOST_MINGW_BUILD_REV.7z"
+readonly x86_64_HOST_MINGW_PATH_URL="https://github.com/niXman/mingw-builds-binaries/releases/download/$HOST_MINGW_VERSION-rt_v$HOST_MINGW_RT_VERSION-rev$HOST_MINGW_BUILD_REV/x86_64-$HOST_MINGW_VERSION-release-posix-{exceptions}-{msvcrt}-rt_v$HOST_MINGW_RT_VERSION-rev$HOST_MINGW_BUILD_REV.7z"
 
 # **************************************************************************
 


### PR DESCRIPTION
This completes our [UCRT adoption plan](https://github.com/niXman/mingw-builds-binaries/issues/29).