### PR TITLE
Add GCC 13.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ At the moment, successfully building the following versions:
   gcc-11.3.0
   gcc-12.1.0
   gcc-12.2.0
+  gcc-13.1.0
   gcc-4.6-branch (currently 4.6.5 prerelease)
   gcc-4.7-branch (currently 4.7.5 prerelease)
   gcc-4.8-branch (currently 4.8.6 prerelease)
@@ -143,7 +144,8 @@ At the moment, successfully building the following versions:
   gcc-10-branch (currently 10.5.0-prerelease)
   gcc-11-branch (currently 11.3.0-prerelease)
   gcc-12-branch (currently 12.3.0-prerelease)
-  gcc-trunk (currently 13.0.0 snapshot)
+  gcc-13-branch (currently 13.2.0-prerelease)
+  gcc-trunk (currently 14.0.0 snapshot)
 ```
 
 Builds also contains patches for building Python 2.7.9 and 3.4.3 versions for support gdb pretty printers.

--- a/build
+++ b/build
@@ -170,7 +170,9 @@ readonly RUN_ARGS="$@"
 	echo "    gcc-12.1.0 (12.1.0 release)"
 	echo "    gcc-12.2.0 (12.2.0 release)"
 	echo "    gcc-12-branch (currently 12.3.0-prerelease)"
-	echo "    gcc-trunk (currently 13.0.0-snapshot)"
+	echo "    gcc-13.1.0 (13.1.0 release)"
+	echo "    gcc-13-branch (currently 13.2.0-prerelease)"
+	echo "    gcc-trunk (currently 14.0.0-snapshot)"
 
 	exit 0
 }

--- a/scripts/gcc-13-branch.sh
+++ b/scripts/gcc-13-branch.sh
@@ -48,16 +48,11 @@ PKG_PRIORITY=main
 #
 
 PKG_PATCHES=(
-	gcc/gcc-4.7-stdthreads.patch
 	gcc/gcc-5.1-iconv.patch
 	gcc/gcc-4.8-libstdc++export.patch
 	gcc/gcc-12-fix-for-windows-not-minding-non-existant-parent-dirs.patch
-	gcc/gcc-4.8.2-windows-lrealpath-no-force-lowercase-nor-backslash.patch
-	gcc/gcc-4.9.1-enable-shared-gnat-implib.mingw.patch
 	gcc/gcc-5.1.0-make-xmmintrin-header-cplusplus-compatible.patch
-	gcc/gcc-12-fix-mingw-pch.patch
 	gcc/gcc-5-dwarf-regression.patch
-	gcc/gcc-5.1.0-fix-libatomic-building-for-threads=win32.patch
 	gcc/gcc-12-ktietz-libgomp.patch
 	gcc/gcc-libgomp-ftime64.patch
 	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
@@ -88,6 +83,9 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-libstdcxx-time=yes
 	--enable-threads=$THREADS_MODEL
+	$( [[ $THREADS_MODEL == win32 ]] \
+		&& echo "--enable-libstdcxx-threads=yes" \
+	)
 	--enable-libgomp
 	--enable-libatomic
 	$( [[ "$MSVCRT_PHOBOS_OK" == yes && "$D_LANG_ENABLED" == yes ]] \
@@ -138,6 +136,7 @@ PKG_CONFIGURE_FLAGS=(
 	CPPFLAGS="\"$COMMON_CPPFLAGS\""
 	LDFLAGS="\"$COMMON_LDFLAGS $( [[ $BUILD_ARCHITECTURE == i686 ]] && echo -Wl,--large-address-aware )\""
 	LD_FOR_TARGET=$PREFIX/bin/ld.exe
+	--with-boot-ldflags="\"$LDFLAGS -Wl,--disable-dynamicbase -static-libstdc++ -static-libgcc\""
 )
 
 #

--- a/scripts/gcc-13-branch.sh
+++ b/scripts/gcc-13-branch.sh
@@ -1,0 +1,158 @@
+
+#
+# The BSD 3-Clause License. http://www.opensource.org/licenses/BSD-3-Clause
+#
+# This file is part of MinGW-W64(mingw-builds: https://github.com/niXman/mingw-builds) project.
+# Copyright (c) 2011-2023 by niXman (i dotty nixman doggy gmail dotty com)
+# Copyright (c) 2012-2015 by Alexpux (alexpux doggy gmail dotty com)
+# All rights reserved.
+#
+# Project: MinGW-Builds ( https://github.com/niXman/mingw-builds )
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# - Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the distribution.
+# - Neither the name of the 'MinGW-W64' nor the names of its contributors may
+#     be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# **************************************************************************
+
+PKG_VERSION=13
+PKG_NAME=gcc-${PKG_VERSION}-branch
+PKG_DIR_NAME=gcc-${PKG_VERSION}-branch
+PKG_TYPE=git
+PKG_URLS=(
+	"https://gcc.gnu.org/git/gcc.git|branch:releases/gcc-$PKG_VERSION|repo:$PKG_TYPE|module:$PKG_DIR_NAME"
+)
+
+PKG_PRIORITY=main
+
+#
+
+PKG_PATCHES=(
+	gcc/gcc-4.7-stdthreads.patch
+	gcc/gcc-5.1-iconv.patch
+	gcc/gcc-4.8-libstdc++export.patch
+	gcc/gcc-12-fix-for-windows-not-minding-non-existant-parent-dirs.patch
+	gcc/gcc-4.8.2-windows-lrealpath-no-force-lowercase-nor-backslash.patch
+	gcc/gcc-4.9.1-enable-shared-gnat-implib.mingw.patch
+	gcc/gcc-5.1.0-make-xmmintrin-header-cplusplus-compatible.patch
+	gcc/gcc-12-fix-mingw-pch.patch
+	gcc/gcc-5-dwarf-regression.patch
+	gcc/gcc-5.1.0-fix-libatomic-building-for-threads=win32.patch
+	gcc/gcc-12-ktietz-libgomp.patch
+	gcc/gcc-libgomp-ftime64.patch
+	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
+	gcc/gcc-10-libgcc-ldflags.patch
+    gcc/gcc-12-replace-abort-with-fancy_abort.patch
+)
+
+#
+
+PKG_CONFIGURE_FLAGS=(
+	--host=$HOST
+	--build=$BUILD
+	--target=$TARGET
+	#
+	--prefix=$MINGWPREFIX
+	--with-sysroot=$PREFIX
+	#--with-gxx-include-dir=$MINGWPREFIX/$TARGET/include/c++
+	#
+	$LINK_TYPE_GCC
+	#
+	$( [[ $USE_MULTILIB == yes ]] \
+		&& echo "--enable-targets=all --enable-multilib" \
+		|| echo "--disable-multilib" \
+	)
+	$( [[ "$DISABLE_GCC_LTO" == yes ]] \
+		&& echo "--enable-languages=$ENABLE_LANGUAGES" \
+		|| echo "--enable-languages=$ENABLE_LANGUAGES,lto"
+	)
+	--enable-libstdcxx-time=yes
+	--enable-threads=$THREADS_MODEL
+	--enable-libgomp
+	--enable-libatomic
+	$( [[ "$MSVCRT_PHOBOS_OK" == yes && "$D_LANG_ENABLED" == yes ]] \
+		&& echo "--enable-libphobos"
+	)
+	$( [[ "$DISABLE_GCC_LTO" == yes ]] \
+		&& echo "--disable-lto" \
+		|| echo "--enable-lto"
+	)
+	--enable-graphite
+	--enable-checking=release
+	--enable-fully-dynamic-string
+	--enable-version-specific-runtime-libs
+	--enable-libstdcxx-filesystem-ts=yes
+	$( [[ $EXCEPTIONS_MODEL == dwarf ]] \
+		&& echo "--disable-sjlj-exceptions --with-dwarf2" \
+	)
+	$( [[ $EXCEPTIONS_MODEL == sjlj ]] \
+		&& echo "--enable-sjlj-exceptions" \
+	)
+	#
+	--disable-libstdcxx-pch
+	--disable-libstdcxx-debug
+	$( [[ $BOOTSTRAPING == yes ]] \
+		&& echo "--enable-bootstrap" \
+		|| echo "--disable-bootstrap" \
+	)
+	--disable-rpath
+	--disable-win32-registry
+	--disable-nls
+	--disable-werror
+	--disable-symvers
+	#
+	--with-gnu-as
+	--with-gnu-ld
+	#
+	$PROCESSOR_OPTIMIZATION
+	$PROCESSOR_TUNE
+	#
+	--with-libiconv
+	--with-system-zlib
+	--with-{gmp,mpfr,mpc,isl}=$PREREQ_DIR/$HOST-$LINK_TYPE_SUFFIX
+	--with-pkgversion="\"$BUILD_ARCHITECTURE-$THREADS_MODEL-$EXCEPTIONS_MODEL${REV_STRING}, $MINGW_W64_PKG_STRING\""
+	--with-bugurl=$BUG_URL
+	#
+	CFLAGS="\"$COMMON_CFLAGS\""
+	CXXFLAGS="\"$COMMON_CXXFLAGS\""
+	CPPFLAGS="\"$COMMON_CPPFLAGS\""
+	LDFLAGS="\"$COMMON_LDFLAGS $( [[ $BUILD_ARCHITECTURE == i686 ]] && echo -Wl,--large-address-aware )\""
+	LD_FOR_TARGET=$PREFIX/bin/ld.exe
+)
+
+#
+
+PKG_MAKE_FLAGS=(
+	-j$JOBS
+	all
+)
+
+#
+
+PKG_INSTALL_FLAGS=(
+	-j1
+	DESTDIR=$BASE_BUILD_DIR
+	$( [[ $STRIP_ON_INSTALL == yes ]] && echo install-strip || echo install )
+)
+
+# **************************************************************************

--- a/scripts/gcc-13.1.0.sh
+++ b/scripts/gcc-13.1.0.sh
@@ -48,20 +48,16 @@ PKG_PRIORITY=main
 #
 
 PKG_PATCHES=(
-	gcc/gcc-4.7-stdthreads.patch
 	gcc/gcc-5.1-iconv.patch
 	gcc/gcc-4.8-libstdc++export.patch
 	gcc/gcc-12-fix-for-windows-not-minding-non-existant-parent-dirs.patch
-	gcc/gcc-4.8.2-windows-lrealpath-no-force-lowercase-nor-backslash.patch
-	gcc/gcc-4.9.1-enable-shared-gnat-implib.mingw.patch
 	gcc/gcc-5.1.0-make-xmmintrin-header-cplusplus-compatible.patch
-	gcc/gcc-12-fix-mingw-pch.patch
 	gcc/gcc-5-dwarf-regression.patch
-	gcc/gcc-5.1.0-fix-libatomic-building-for-threads=win32.patch
 	gcc/gcc-12-ktietz-libgomp.patch
 	gcc/gcc-libgomp-ftime64.patch
 	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
 	gcc/gcc-10-libgcc-ldflags.patch
+    gcc/gcc-12-replace-abort-with-fancy_abort.patch
 )
 
 #
@@ -87,6 +83,9 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-libstdcxx-time=yes
 	--enable-threads=$THREADS_MODEL
+	$( [[ $THREADS_MODEL == win32 ]] \
+		&& echo "--enable-libstdcxx-threads=yes" \
+	)
 	--enable-libgomp
 	--enable-libatomic
 	$( [[ "$MSVCRT_PHOBOS_OK" == yes && "$D_LANG_ENABLED" == yes ]] \

--- a/scripts/gcc-13.1.0.sh
+++ b/scripts/gcc-13.1.0.sh
@@ -1,0 +1,158 @@
+
+#
+# The BSD 3-Clause License. http://www.opensource.org/licenses/BSD-3-Clause
+#
+# This file is part of MinGW-W64(mingw-builds: https://github.com/niXman/mingw-builds) project.
+# Copyright (c) 2011-2023 by niXman (i dotty nixman doggy gmail dotty com)
+# Copyright (c) 2012-2015 by Alexpux (alexpux doggy gmail dotty com)
+# All rights reserved.
+#
+# Project: MinGW-Builds ( https://github.com/niXman/mingw-builds )
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# - Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the distribution.
+# - Neither the name of the 'MinGW-W64' nor the names of its contributors may
+#     be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# **************************************************************************
+
+PKG_VERSION=13.1.0
+PKG_NAME=gcc-${PKG_VERSION}
+PKG_DIR_NAME=gcc-${PKG_VERSION}
+PKG_TYPE=.tar.xz
+PKG_URLS=(
+	"https://ftp.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}${PKG_TYPE}"
+)
+
+PKG_PRIORITY=main
+
+#
+
+PKG_PATCHES=(
+	gcc/gcc-4.7-stdthreads.patch
+	gcc/gcc-5.1-iconv.patch
+	gcc/gcc-4.8-libstdc++export.patch
+	gcc/gcc-12-fix-for-windows-not-minding-non-existant-parent-dirs.patch
+	gcc/gcc-4.8.2-windows-lrealpath-no-force-lowercase-nor-backslash.patch
+	gcc/gcc-4.9.1-enable-shared-gnat-implib.mingw.patch
+	gcc/gcc-5.1.0-make-xmmintrin-header-cplusplus-compatible.patch
+	gcc/gcc-12-fix-mingw-pch.patch
+	gcc/gcc-5-dwarf-regression.patch
+	gcc/gcc-5.1.0-fix-libatomic-building-for-threads=win32.patch
+	gcc/gcc-12-ktietz-libgomp.patch
+	gcc/gcc-libgomp-ftime64.patch
+	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
+	gcc/gcc-10-libgcc-ldflags.patch
+)
+
+#
+
+PKG_CONFIGURE_FLAGS=(
+	--host=$HOST
+	--build=$BUILD
+	--target=$TARGET
+	#
+	--prefix=$MINGWPREFIX
+	--with-sysroot=$PREFIX
+	#--with-gxx-include-dir=$MINGWPREFIX/$TARGET/include/c++
+	#
+	$LINK_TYPE_GCC
+	#
+	$( [[ $USE_MULTILIB == yes ]] \
+		&& echo "--enable-targets=all --enable-multilib" \
+		|| echo "--disable-multilib" \
+	)
+	$( [[ "$DISABLE_GCC_LTO" == yes ]] \
+		&& echo "--enable-languages=$ENABLE_LANGUAGES" \
+		|| echo "--enable-languages=$ENABLE_LANGUAGES,lto"
+	)
+	--enable-libstdcxx-time=yes
+	--enable-threads=$THREADS_MODEL
+	--enable-libgomp
+	--enable-libatomic
+	$( [[ "$MSVCRT_PHOBOS_OK" == yes && "$D_LANG_ENABLED" == yes ]] \
+		&& echo "--enable-libphobos"
+	)
+	$( [[ "$DISABLE_GCC_LTO" == yes ]] \
+		&& echo "--disable-lto" \
+		|| echo "--enable-lto"
+	)
+	--enable-graphite
+	--enable-checking=release
+	--enable-fully-dynamic-string
+	--enable-version-specific-runtime-libs
+	--enable-libstdcxx-filesystem-ts=yes
+	$( [[ $EXCEPTIONS_MODEL == dwarf ]] \
+		&& echo "--disable-sjlj-exceptions --with-dwarf2" \
+	)
+	$( [[ $EXCEPTIONS_MODEL == sjlj ]] \
+		&& echo "--enable-sjlj-exceptions" \
+	)
+	#
+	--disable-libstdcxx-pch
+	--disable-libstdcxx-debug
+	$( [[ $BOOTSTRAPING == yes ]] \
+		&& echo "--enable-bootstrap" \
+		|| echo "--disable-bootstrap" \
+	)
+	--disable-rpath
+	--disable-win32-registry
+	--disable-nls
+	--disable-werror
+	--disable-symvers
+	#
+	--with-gnu-as
+	--with-gnu-ld
+	#
+	$PROCESSOR_OPTIMIZATION
+	$PROCESSOR_TUNE
+	#
+	--with-libiconv
+	--with-system-zlib
+	--with-{gmp,mpfr,mpc,isl}=$PREREQ_DIR/$HOST-$LINK_TYPE_SUFFIX
+	--with-pkgversion="\"$BUILD_ARCHITECTURE-$THREADS_MODEL-$EXCEPTIONS_MODEL${REV_STRING}, $MINGW_W64_PKG_STRING\""
+	--with-bugurl=$BUG_URL
+	#
+	CFLAGS="\"$COMMON_CFLAGS\""
+	CXXFLAGS="\"$COMMON_CXXFLAGS\""
+	CPPFLAGS="\"$COMMON_CPPFLAGS\""
+	LDFLAGS="\"$COMMON_LDFLAGS $( [[ $BUILD_ARCHITECTURE == i686 ]] && echo -Wl,--large-address-aware )\""
+	LD_FOR_TARGET=$PREFIX/bin/ld.exe
+	--with-boot-ldflags="\"$LDFLAGS -Wl,--disable-dynamicbase -static-libstdc++ -static-libgcc\""
+)
+
+#
+
+PKG_MAKE_FLAGS=(
+	-j$JOBS
+	all
+)
+
+#
+
+PKG_INSTALL_FLAGS=(
+	-j1
+	DESTDIR=$BASE_BUILD_DIR
+	$( [[ $STRIP_ON_INSTALL == yes ]] && echo install-strip || echo install )
+)
+
+# **************************************************************************


### PR DESCRIPTION
Successfully built GCC 13.1.0 with `x86_64-win32-seh-ucrt-rv_v10`. 

(But without `--bootstrapall` flag, the build failed with some strange error. Should I open an issue for this?)