### PR TITLE
Update GitHub Actions to use actions/checkout@v3

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -52,7 +52,7 @@ jobs:
           }
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: msys2/setup-msys2@v2
       with:


### PR DESCRIPTION
This will fix the deprecation warnings in GitHub Actions.