### PR TITLE
gcc: disable libssp if mingw-w64 is v11 or later

### DIFF
--- a/scripts/gcc-12-branch.sh
+++ b/scripts/gcc-12-branch.sh
@@ -109,6 +109,9 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
+	$( [[ $RUNTIME_MAJOR_VERSION -ge 11 ]] \
+		&& echo "--disable-libssp" \
+	)
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-12.2.0.sh
+++ b/scripts/gcc-12.2.0.sh
@@ -108,6 +108,9 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
+	$( [[ $RUNTIME_MAJOR_VERSION -ge 11 ]] \
+		&& echo "--disable-libssp" \
+	)
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-12.3.0.sh
+++ b/scripts/gcc-12.3.0.sh
@@ -109,6 +109,9 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
+	$( [[ $RUNTIME_MAJOR_VERSION -ge 11 ]] \
+		&& echo "--disable-libssp" \
+	)
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-13-branch.sh
+++ b/scripts/gcc-13-branch.sh
@@ -107,6 +107,9 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
+	$( [[ $RUNTIME_MAJOR_VERSION -ge 11 ]] \
+		&& echo "--disable-libssp" \
+	)
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-13.1.0.sh
+++ b/scripts/gcc-13.1.0.sh
@@ -107,6 +107,9 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
+	$( [[ $RUNTIME_MAJOR_VERSION -ge 11 ]] \
+		&& echo "--disable-libssp" \
+	)
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \

--- a/scripts/gcc-trunk.sh
+++ b/scripts/gcc-trunk.sh
@@ -107,6 +107,9 @@ PKG_CONFIGURE_FLAGS=(
 		&& echo "--enable-sjlj-exceptions" \
 	)
 	#
+	$( [[ $RUNTIME_MAJOR_VERSION -ge 11 ]] \
+		&& echo "--disable-libssp" \
+	)
 	--disable-libstdcxx-pch
 	--disable-libstdcxx-debug
 	$( [[ $BOOTSTRAPING == yes ]] \


### PR DESCRIPTION
Mingw-w64 v11 has implemented stack protection routines, so libssp is no longer needed.