### PR TITLE
Add support for mcf thread model

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -31,6 +31,11 @@ jobs:
             build_cmd: "--mode=gcc-13.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v11 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
           }
         - {
+            name: "x86_64 mcf seh ucrt",
+            artifact: "x86_64-13.2.0-release-mcf-seh-ucrt-rt_v11-rev0.7z",
+            build_cmd: "--mode=gcc-13.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v11 --threads=mcf --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
+          }
+        - {
             name: "i686 posix dwarf msvcrt",
             artifact: "i686-13.2.0-release-posix-dwarf-msvcrt-rt_v11-rev0.7z",
             build_cmd: "--mode=gcc-13.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v11 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --logviewer-command=cat"
@@ -49,6 +54,11 @@ jobs:
             name: "i686 win32 dwarf ucrt",
             artifact: "i686-13.2.0-release-win32-dwarf-ucrt-rt_v11-rev0.7z",
             build_cmd: "--mode=gcc-13.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v11 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
+          }
+        - {
+            name: "i686 mcf dwarf ucrt",
+            artifact: "i686-13.2.0-release-mcf-dwarf-ucrt-rt_v11-rev0.7z",
+            build_cmd: "--mode=gcc-13.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v11 --threads=mcf --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
           }
 
     steps:
@@ -119,6 +129,10 @@ jobs:
             artifact: "x86_64-13.2.0-release-win32-seh-ucrt-rt_v11-rev0.7z"
           }
         - {
+            name: "x86_64 mcf seh ucrt",
+            artifact: "x86_64-13.2.0-release-mcf-seh-ucrt-rt_v11-rev0.7z"
+          }
+        - {
             name: "i686 posix dwarf msvcrt",
             artifact: "i686-13.2.0-release-posix-dwarf-msvcrt-rt_v11-rev0.7z"
           }
@@ -133,6 +147,10 @@ jobs:
         - {
             name: "i686 win32 dwarf ucrt",
             artifact: "i686-13.2.0-release-win32-dwarf-ucrt-rt_v11-rev0.7z"
+          }
+        - {
+            name: "i686 mcf dwarf ucrt",
+            artifact: "i686-13.2.0-release-mcf-dwarf-ucrt-rt_v11-rev0.7z"
           }
 
     needs: release

--- a/build
+++ b/build
@@ -522,6 +522,10 @@ esac
 	die "\"$EXCEPTIONS_MODEL\" exceptions not allowed on multilib architecture. terminate."
 }
 
+[[ $BUILD_MODE == gcc && $THREADS_MODEL == mcf && `func_map_gcc_name_to_gcc_version $BUILD_MODE_VERSION | cut -d. -f1` -lt 13 ]] && {
+	die "\"$THREADS_MODEL\" thread model requires GCC 13 or later. terminate."
+}
+
 [[ $BUILD_MODE != gcc && $COMPRESSING_SRCS == yes ]] && {
 	die "compressing sources for \"$BUILD_MODE\" mode is currently unimplemented. terminate."
 }

--- a/build
+++ b/build
@@ -67,7 +67,7 @@ readonly RUN_ARGS="$@"
 	echo "    --bootstrapall             - bootstraping GCC & all prerequisites"
 	echo "    --no-multilib              - build GCC without multilib support"
 	echo "    --rev=N                    - specifies number of the build revision"
-	echo "    --threads=<model>          - specifies the threads model for GCC/libstdc++, available: win32, posix"
+	echo "    --threads=<model>          - specifies the threads model for GCC/libstdc++, available: win32, posix, mcf"
 	echo "    --static-gcc               - build static GCC"
 	echo "    --with-default-msvcrt=     - specifies msvc version the toolchain will target"
 	echo "                                 <msvcrt|msvcr80|msvcr90|msvcr100|msvcr110|msvcr120|ucrt>"
@@ -375,10 +375,10 @@ while [[ $# > 0 ]]; do
 		--threads=*)
 			THREADS_MODEL=${1/--threads=/}
 			case $THREADS_MODEL in
-				win32|posix)
+				win32|posix|mcf)
 				;;
 				*)
-					die "\"$THREADS_MODEL\" is not valid threads model. available models: posix, win32. terminate"
+					die "\"$THREADS_MODEL\" is not valid threads model. available models: posix, win32, mcf. terminate"
 				;;
 			esac
 		;;
@@ -661,6 +661,10 @@ case $BUILD_ARCHITECTURE in
 		}
 	;;
 esac
+
+[[ $THREADS_MODEL == mcf ]] && {
+	export PATH=$PREREQ_DIR/$BUILD_ARCHITECTURE-mcfgthread/bin:$PATH
+}
 
 [[ $LINK_TYPE_SUFFIX == shared ]] && {
 	export PATH=$PREREQ_DIR/$HOST-$LINK_TYPE_SUFFIX/bin:$PREREQ_DIR/$BUILD_ARCHITECTURE-libiconv-$LINK_TYPE_SUFFIX/bin:$PREREQ_DIR/$BUILD_ARCHITECTURE-zlib-$LINK_TYPE_SUFFIX/bin:$PATH

--- a/library/subtargets.sh
+++ b/library/subtargets.sh
@@ -59,6 +59,16 @@ function func_get_subtargets {
 		$( [[ $1 == clang || $2 == 4* ]] && echo cloog )
 		mingw-w64-download
 		mingw-w64-api
+		$( \
+			[[ $THREADS_MODEL == mcf ]] && { \
+				[[ $USE_MULTILIB == yes ]] && { \
+					echo "mcfgthread|$BUILD_ARCHITECTURE"; \
+					echo "mcfgthread|$REVERSE_ARCHITECTURE"; \
+				} || { \
+					echo mcfgthread; \
+				} \
+			} \
+		)
 		mingw-w64-crt
 		$( \
 			[[ $USE_MULTILIB == yes ]] && { \

--- a/licenses/mcfgthread/LICENSE.TXT
+++ b/licenses/mcfgthread/LICENSE.TXT
@@ -1,0 +1,865 @@
+Files that are conventionally called 'headers', whose names shall end with
+the extended regular expression `\.[hci](pp)?`, are placed into the public
+domain, without any warranty. The other files are licensed under LGPL. This
+guarantees most developers enough freedom to do whatever they want with
+these headers.
+
+============================================================================
+
+MCF Gthread is free software: you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option)
+any later version.
+
+MCF Gthread is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with MCF Gthread. If not, see <https://www.gnu.org/licenses/>.
+
+============================================================================
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.
+
+===============================================================================
+
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/patches/mingw-w64/9001-crt-Mark-atexit-as-DATA-because-it-s-always-overridd.patch
+++ b/patches/mingw-w64/9001-crt-Mark-atexit-as-DATA-because-it-s-always-overridd.patch
@@ -1,0 +1,195 @@
+From d62ec23c621159c57b5dc4634f9b1b6db4ea4e7e Mon Sep 17 00:00:00 2001
+From: LIU Hao <lh_mouse@126.com>
+Date: Fri, 7 Oct 2022 22:42:04 +0800
+Subject: [PATCH 2/5] crt: Mark `atexit()` as DATA because it's always
+ overridden
+
+Signed-off-by: LIU Hao <lh_mouse@126.com>
+---
+ mingw-w64-crt/lib-common/msvcr120_app.def.in | 2 +-
+ mingw-w64-crt/lib32/msvcr120.def.in          | 2 +-
+ mingw-w64-crt/lib32/msvcr120d.def.in         | 2 +-
+ mingw-w64-crt/lib32/msvcr70.def.in           | 2 +-
+ mingw-w64-crt/lib32/msvcr71.def.in           | 2 +-
+ mingw-w64-crt/lib32/msvcrt10.def.in          | 2 +-
+ mingw-w64-crt/lib32/msvcrt20.def.in          | 2 +-
+ mingw-w64-crt/lib32/msvcrt40.def.in          | 2 +-
+ mingw-w64-crt/lib64/msvcr120.def.in          | 2 +-
+ mingw-w64-crt/lib64/msvcr120d.def.in         | 2 +-
+ mingw-w64-crt/libarm32/kernelbase.def        | 2 +-
+ mingw-w64-crt/libarm32/msvcr110.def          | 2 +-
+ mingw-w64-crt/libarm32/msvcr120_clr0400.def  | 2 +-
+ 13 files changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/mingw-w64-crt/lib-common/msvcr120_app.def.in b/mingw-w64-crt/lib-common/msvcr120_app.def.in
+index 10cf84d07..ddb407d00 100644
+--- a/mingw-w64-crt/lib-common/msvcr120_app.def.in
++++ b/mingw-w64-crt/lib-common/msvcr120_app.def.in
+@@ -2029,7 +2029,7 @@ F_NON_I386(atanf)
+ F_X86_ANY(atanh)
+ F_X86_ANY(atanhf)
+ F_X86_ANY(atanhl)
+-atexit
++atexit DATA
+ atof
+ atoi
+ atol
+diff --git a/mingw-w64-crt/lib32/msvcr120.def.in b/mingw-w64-crt/lib32/msvcr120.def.in
+index d1bc9bc15..6db27845a 100644
+--- a/mingw-w64-crt/lib32/msvcr120.def.in
++++ b/mingw-w64-crt/lib32/msvcr120.def.in
+@@ -1864,7 +1864,7 @@ atan2
+ atanh
+ atanhf
+ atanhl
+-atexit
++atexit DATA
+ atof
+ atoi
+ atol
+diff --git a/mingw-w64-crt/lib32/msvcr120d.def.in b/mingw-w64-crt/lib32/msvcr120d.def.in
+index bd95baebd..5ff03bda2 100644
+--- a/mingw-w64-crt/lib32/msvcr120d.def.in
++++ b/mingw-w64-crt/lib32/msvcr120d.def.in
+@@ -1931,7 +1931,7 @@ atan2
+ atanh
+ atanhf
+ atanhl
+-atexit
++atexit DATA
+ atof
+ atoi
+ atol
+diff --git a/mingw-w64-crt/lib32/msvcr70.def.in b/mingw-w64-crt/lib32/msvcr70.def.in
+index 721dd7959..59f6ce2df 100644
+--- a/mingw-w64-crt/lib32/msvcr70.def.in
++++ b/mingw-w64-crt/lib32/msvcr70.def.in
+@@ -717,7 +717,7 @@ asctime
+ asin
+ atan
+ atan2
+-atexit
++atexit DATA
+ atof
+ atoi
+ atol
+diff --git a/mingw-w64-crt/lib32/msvcr71.def.in b/mingw-w64-crt/lib32/msvcr71.def.in
+index 7e120a22f..1da46dcdf 100644
+--- a/mingw-w64-crt/lib32/msvcr71.def.in
++++ b/mingw-w64-crt/lib32/msvcr71.def.in
+@@ -712,7 +712,7 @@ asctime
+ asin
+ atan
+ atan2
+-atexit
++atexit DATA
+ atof
+ atoi
+ atol
+diff --git a/mingw-w64-crt/lib32/msvcrt10.def.in b/mingw-w64-crt/lib32/msvcrt10.def.in
+index 58c4a3673..af82d7fd5 100644
+--- a/mingw-w64-crt/lib32/msvcrt10.def.in
++++ b/mingw-w64-crt/lib32/msvcrt10.def.in
+@@ -1115,7 +1115,7 @@ asctime
+ asin
+ atan
+ atan2
+-atexit
++atexit DATA
+ atof
+ atoi
+ atol
+diff --git a/mingw-w64-crt/lib32/msvcrt20.def.in b/mingw-w64-crt/lib32/msvcrt20.def.in
+index 51999bd09..1ad59beb9 100644
+--- a/mingw-w64-crt/lib32/msvcrt20.def.in
++++ b/mingw-w64-crt/lib32/msvcrt20.def.in
+@@ -1383,7 +1383,7 @@ asctime
+ asin
+ atan
+ atan2
+-atexit
++atexit DATA
+ atof
+ atoi
+ atol
+diff --git a/mingw-w64-crt/lib32/msvcrt40.def.in b/mingw-w64-crt/lib32/msvcrt40.def.in
+index 0d1104a9a..03094dce8 100644
+--- a/mingw-w64-crt/lib32/msvcrt40.def.in
++++ b/mingw-w64-crt/lib32/msvcrt40.def.in
+@@ -1467,7 +1467,7 @@ asctime
+ asin
+ atan
+ atan2
+-atexit
++atexit DATA
+ atof
+ atoi
+ atol
+diff --git a/mingw-w64-crt/lib64/msvcr120.def.in b/mingw-w64-crt/lib64/msvcr120.def.in
+index 5ae5ecfc8..8c6dd5dd6 100644
+--- a/mingw-w64-crt/lib64/msvcr120.def.in
++++ b/mingw-w64-crt/lib64/msvcr120.def.in
+@@ -1806,7 +1806,7 @@ atanf
+ atanh
+ atanhf
+ atanhl
+-atexit
++atexit DATA
+ atof
+ atoi
+ atol
+diff --git a/mingw-w64-crt/lib64/msvcr120d.def.in b/mingw-w64-crt/lib64/msvcr120d.def.in
+index 1d9200671..dca76d1e8 100644
+--- a/mingw-w64-crt/lib64/msvcr120d.def.in
++++ b/mingw-w64-crt/lib64/msvcr120d.def.in
+@@ -1870,7 +1870,7 @@ atanf
+ atanh
+ atanhf
+ atanhl
+-atexit
++atexit DATA
+ atof
+ atoi
+ atol
+diff --git a/mingw-w64-crt/libarm32/kernelbase.def b/mingw-w64-crt/libarm32/kernelbase.def
+index 954ea2dc1..d6a487db1 100644
+--- a/mingw-w64-crt/libarm32/kernelbase.def
++++ b/mingw-w64-crt/libarm32/kernelbase.def
+@@ -1889,7 +1889,7 @@ _invalid_parameter
+ _onexit
+ _purecall
+ _time64
+-atexit
++atexit DATA
+ exit
+ hgets
+ hwprintf
+diff --git a/mingw-w64-crt/libarm32/msvcr110.def b/mingw-w64-crt/libarm32/msvcr110.def
+index 4d3d0ee6d..0c4aa92af 100644
+--- a/mingw-w64-crt/libarm32/msvcr110.def
++++ b/mingw-w64-crt/libarm32/msvcr110.def
+@@ -1392,7 +1392,7 @@ atan
+ atan2
+ atan2f
+ atanf
+-atexit
++atexit DATA
+ atof
+ atoi
+ atol
+diff --git a/mingw-w64-crt/libarm32/msvcr120_clr0400.def b/mingw-w64-crt/libarm32/msvcr120_clr0400.def
+index ab659babc..3a153da53 100644
+--- a/mingw-w64-crt/libarm32/msvcr120_clr0400.def
++++ b/mingw-w64-crt/libarm32/msvcr120_clr0400.def
+@@ -1391,7 +1391,7 @@ atan
+ atan2
+ atan2f
+ atanf
+-atexit
++atexit DATA
+ atof
+ atoi
+ atol
+-- 
+2.41.0
+

--- a/patches/mingw-w64/9002-crt-Provide-wrappers-for-exit-in-libmingwex.patch
+++ b/patches/mingw-w64/9002-crt-Provide-wrappers-for-exit-in-libmingwex.patch
@@ -1,0 +1,772 @@
+From 5ef09e6baf078e9db654027dc8b25ae7e502f6b8 Mon Sep 17 00:00:00 2001
+From: LIU Hao <lh_mouse@126.com>
+Date: Fri, 7 Oct 2022 22:46:50 +0800
+Subject: [PATCH 3/5] crt: Provide wrappers for `*exit()` in libmingwex
+
+This should have no effect on functionality, but allows further
+customization of them.
+
+Signed-off-by: LIU Hao <lh_mouse@126.com>
+---
+ mingw-w64-crt/Makefile.am                     |  2 +-
+ mingw-w64-crt/crt/exit_wrappers.c             | 25 +++++++++++++++++
+ mingw-w64-crt/crt/ucrt_exit_wrappers.c        | 27 +++++++++++++++++++
+ mingw-w64-crt/crt/ucrtbase_compat.c           |  4 ++-
+ .../api-ms-win-crt-runtime-l1-1-0.def.in      |  8 +++---
+ mingw-w64-crt/lib-common/msvcr120_app.def.in  |  4 +--
+ mingw-w64-crt/lib-common/msvcrt.def.in        |  4 +--
+ mingw-w64-crt/lib-common/ucrtbase.def.in      |  8 +++---
+ mingw-w64-crt/lib32/crtdll.def.in             |  4 +--
+ mingw-w64-crt/lib32/msvcr100.def.in           |  4 +--
+ mingw-w64-crt/lib32/msvcr110.def.in           |  4 +--
+ mingw-w64-crt/lib32/msvcr120.def.in           |  4 +--
+ mingw-w64-crt/lib32/msvcr120d.def.in          |  4 +--
+ mingw-w64-crt/lib32/msvcr70.def.in            |  4 +--
+ mingw-w64-crt/lib32/msvcr71.def.in            |  4 +--
+ mingw-w64-crt/lib32/msvcr80.def.in            |  4 +--
+ mingw-w64-crt/lib32/msvcr90.def.in            |  4 +--
+ mingw-w64-crt/lib32/msvcr90d.def.in           |  4 +--
+ mingw-w64-crt/lib32/msvcrt10.def.in           |  4 +--
+ mingw-w64-crt/lib32/msvcrt20.def.in           |  4 +--
+ mingw-w64-crt/lib32/msvcrt40.def.in           |  4 +--
+ mingw-w64-crt/lib64/msvcr100.def.in           |  4 +--
+ mingw-w64-crt/lib64/msvcr110.def.in           |  4 +--
+ mingw-w64-crt/lib64/msvcr120.def.in           |  4 +--
+ mingw-w64-crt/lib64/msvcr120d.def.in          |  4 +--
+ mingw-w64-crt/lib64/msvcr80.def.in            |  4 +--
+ mingw-w64-crt/lib64/msvcr90.def.in            |  4 +--
+ mingw-w64-crt/lib64/msvcr90d.def.in           |  4 +--
+ mingw-w64-crt/libarm32/kernelbase.def         |  4 +--
+ mingw-w64-crt/libarm32/msvcr110.def           |  4 +--
+ mingw-w64-crt/libarm32/msvcr120_clr0400.def   |  4 +--
+ 31 files changed, 114 insertions(+), 60 deletions(-)
+ create mode 100644 mingw-w64-crt/crt/exit_wrappers.c
+ create mode 100644 mingw-w64-crt/crt/ucrt_exit_wrappers.c
+
+diff --git a/mingw-w64-crt/Makefile.am b/mingw-w64-crt/Makefile.am
+index 24f86c6c6..54799d6be 100644
+--- a/mingw-w64-crt/Makefile.am
++++ b/mingw-w64-crt/Makefile.am
+@@ -129,7 +129,7 @@ src_libmingw32=include/oscalls.h include/internal.h include/sect_attribs.h \
+   crt/usermatherr.c   \
+   crt/xtxtmode.c      crt/crt_handler.c    \
+   crt/tlsthrd.c       crt/tlsmthread.c     crt/tlsmcrt.c   \
+-  crt/cxa_atexit.c    crt/cxa_thread_atexit.c crt/tls_atexit.c
++  crt/cxa_atexit.c    crt/cxa_thread_atexit.c   crt/tls_atexit.c   crt/exit_wrappers.c   crt/ucrt_exit_wrappers.c
+ 
+ src_libscrnsave=libsrc/scrnsave.c
+ src_libscrnsavw=libsrc/scrnsave.c
+diff --git a/mingw-w64-crt/crt/exit_wrappers.c b/mingw-w64-crt/crt/exit_wrappers.c
+new file mode 100644
+index 000000000..256c26d07
+--- /dev/null
++++ b/mingw-w64-crt/crt/exit_wrappers.c
+@@ -0,0 +1,25 @@
++/**
++ * This file has no copyright assigned and is placed in the Public Domain.
++ * This file is part of the mingw-w64 runtime package.
++ * No warranty is given; refer to the file DISCLAIMER.PD within this package.
++ */
++
++#include <_mingw.h>
++
++/* `exit()`, C89  */
++void exit(int status) __attribute__((__noreturn__));
++extern void (*__MINGW_IMP_SYMBOL(exit))(int) __attribute__((__noreturn__));
++
++void exit(int status)
++{
++  (*__MINGW_IMP_SYMBOL(exit))(status);
++}
++
++/* `_exit()`, POSIX  */
++void _exit(int status) __attribute__((__noreturn__));
++extern void (*__MINGW_IMP_SYMBOL(_exit))(int) __attribute__((__noreturn__));
++
++void _exit(int status)
++{
++  (*__MINGW_IMP_SYMBOL(_exit))(status);
++}
+diff --git a/mingw-w64-crt/crt/ucrt_exit_wrappers.c b/mingw-w64-crt/crt/ucrt_exit_wrappers.c
+new file mode 100644
+index 000000000..112d8e3c7
+--- /dev/null
++++ b/mingw-w64-crt/crt/ucrt_exit_wrappers.c
+@@ -0,0 +1,27 @@
++/**
++ * This file has no copyright assigned and is placed in the Public Domain.
++ * This file is part of the mingw-w64 runtime package.
++ * No warranty is given; refer to the file DISCLAIMER.PD within this package.
++ */
++
++#undef __MSVCRT_VERSION__
++#define _UCRT
++#include <_mingw.h>
++
++/* `quick_exit()`, C99  */
++void quick_exit(int status) __attribute__((__noreturn__));
++extern void (*__MINGW_IMP_SYMBOL(quick_exit))(int) __attribute__((__noreturn__));
++
++void quick_exit(int status)
++{
++  (*__MINGW_IMP_SYMBOL(quick_exit))(status);
++}
++
++/* `_Exit()`, C99  */
++void _Exit(int status) __attribute__((__noreturn__));
++extern void (*__MINGW_IMP_SYMBOL(_Exit))(int) __attribute__((__noreturn__));
++
++void _Exit(int status)
++{
++  (*__MINGW_IMP_SYMBOL(_Exit))(status);
++}
+diff --git a/mingw-w64-crt/crt/ucrtbase_compat.c b/mingw-w64-crt/crt/ucrtbase_compat.c
+index 31a3ee3f1..9eb33e534 100644
+--- a/mingw-w64-crt/crt/ucrtbase_compat.c
++++ b/mingw-w64-crt/crt/ucrtbase_compat.c
+@@ -102,9 +102,11 @@ int __cdecl at_quick_exit(void (__cdecl *func)(void))
+ 
+ int __cdecl (*__MINGW_IMP_SYMBOL(at_quick_exit))(void (__cdecl *)(void)) = at_quick_exit;
+ 
++extern void (*__MINGW_IMP_SYMBOL(_exit))(int) __attribute__((__noreturn__));
++
+ void __cdecl __MINGW_ATTRIB_NORETURN _amsg_exit(int ret) {
+   fprintf(stderr, "runtime error %d\n", ret);
+-  _exit(255);
++  (*__MINGW_IMP_SYMBOL(_exit))(255);
+ }
+ 
+ unsigned int __cdecl _get_output_format(void)
+diff --git a/mingw-w64-crt/lib-common/api-ms-win-crt-runtime-l1-1-0.def.in b/mingw-w64-crt/lib-common/api-ms-win-crt-runtime-l1-1-0.def.in
+index ea310d426..33e4f5504 100644
+--- a/mingw-w64-crt/lib-common/api-ms-win-crt-runtime-l1-1-0.def.in
++++ b/mingw-w64-crt/lib-common/api-ms-win-crt-runtime-l1-1-0.def.in
+@@ -4,7 +4,7 @@ EXPORTS
+ 
+ #include "func.def.in"
+ 
+-_Exit
++_Exit DATA
+ F_I386(__control87_2)
+ __doserrno
+ __fpe_flt_rounds
+@@ -42,7 +42,7 @@ _endthread
+ _endthreadex
+ _errno
+ _execute_onexit_table
+-_exit
++_exit DATA
+ F_NON_I386(_fpieee_flt)
+ ; DATA added manually
+ _fpreset DATA
+@@ -96,7 +96,7 @@ _wcserror_s
+ _wperror
+ _wsystem
+ abort
+-exit
++exit DATA
+ ; Don't use the float env functions from UCRT; fesetround doesn't seem to have
+ ; any effect on the FPU control word as required by other libmingwex math
+ ; routines.
+@@ -110,7 +110,7 @@ fesetexceptflag DATA
+ fesetround DATA
+ fetestexcept DATA
+ perror
+-quick_exit
++quick_exit DATA
+ raise
+ set_terminate
+ signal
+diff --git a/mingw-w64-crt/lib-common/msvcr120_app.def.in b/mingw-w64-crt/lib-common/msvcr120_app.def.in
+index ddb407d00..33f2e9345 100644
+--- a/mingw-w64-crt/lib-common/msvcr120_app.def.in
++++ b/mingw-w64-crt/lib-common/msvcr120_app.def.in
+@@ -1080,7 +1080,7 @@ F_ARM32(_execv)
+ F_ARM32(_execve)
+ F_ARM32(_execvp)
+ F_ARM32(_execvpe)
+-_exit
++_exit DATA
+ F_X86_ANY(_exit_app)
+ _expand
+ F_X86_ANY(_fclose_nolock)
+@@ -2143,7 +2143,7 @@ erfcl
+ erff
+ erfl
+ #endif
+-exit
++exit DATA
+ exp
+ exp2
+ exp2f
+diff --git a/mingw-w64-crt/lib-common/msvcrt.def.in b/mingw-w64-crt/lib-common/msvcrt.def.in
+index 1f8f95b17..255080a2e 100644
+--- a/mingw-w64-crt/lib-common/msvcrt.def.in
++++ b/mingw-w64-crt/lib-common/msvcrt.def.in
+@@ -485,7 +485,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ F_ARM_ANY(_expand_dbg)
+ _fcloseall
+@@ -1356,7 +1356,7 @@ F_NON_I386(coshf DATA)
+ ctime
+ difftime
+ div
+-exit
++exit DATA
+ exp F_X86_ANY(DATA)
+ F_NON_I386(expf F_X86_ANY(DATA))
+ F_ARM_ANY(expl == exp)
+diff --git a/mingw-w64-crt/lib-common/ucrtbase.def.in b/mingw-w64-crt/lib-common/ucrtbase.def.in
+index 0b83b04e7..3fb041727 100644
+--- a/mingw-w64-crt/lib-common/ucrtbase.def.in
++++ b/mingw-w64-crt/lib-common/ucrtbase.def.in
+@@ -30,7 +30,7 @@ _CreateFrameInfo
+ F_I386(_CxxThrowException@8)
+ F_NON_I386(_CxxThrowException)
+ F_I386(_EH_prolog)
+-_Exit
++_Exit DATA
+ _FCbuild
+ _FCmulcc
+ _FCmulcr
+@@ -299,7 +299,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -2305,7 +2305,7 @@ erfcf
+ erfcl F_X86_ANY(DATA)
+ erff
+ erfl F_X86_ANY(DATA)
+-exit
++exit DATA
+ exp F_X86_ANY(DATA)
+ exp2
+ exp2f
+@@ -2501,7 +2501,7 @@ putwc
+ putwchar
+ qsort
+ qsort_s
+-quick_exit
++quick_exit DATA
+ raise
+ rand
+ rand_s
+diff --git a/mingw-w64-crt/lib32/crtdll.def.in b/mingw-w64-crt/lib32/crtdll.def.in
+index d8b5bd821..b5c99d4af 100644
+--- a/mingw-w64-crt/lib32/crtdll.def.in
++++ b/mingw-w64-crt/lib32/crtdll.def.in
+@@ -269,7 +269,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -552,7 +552,7 @@ ctime DATA
+ ;_ctime32 = ctime
+ difftime
+ div
+-exit
++exit DATA
+ exp DATA
+ fabs DATA
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcr100.def.in b/mingw-w64-crt/lib32/msvcr100.def.in
+index e2e0e18c7..d86f5f5b2 100644
+--- a/mingw-w64-crt/lib32/msvcr100.def.in
++++ b/mingw-w64-crt/lib32/msvcr100.def.in
+@@ -834,7 +834,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1704,7 +1704,7 @@ cos DATA
+ ; If we implement cosh too, we can set it to DATA only.
+ cosh
+ div
+-exit
++exit DATA
+ exp DATA
+ fabs DATA
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcr110.def.in b/mingw-w64-crt/lib32/msvcr110.def.in
+index 2045e0a54..bf4979031 100644
+--- a/mingw-w64-crt/lib32/msvcr110.def.in
++++ b/mingw-w64-crt/lib32/msvcr110.def.in
+@@ -957,7 +957,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1837,7 +1837,7 @@ cos DATA
+ ; If we implement cosh, we can set it to DATA only.
+ cosh
+ div
+-exit
++exit DATA
+ exp DATA
+ fabs DATA
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcr120.def.in b/mingw-w64-crt/lib32/msvcr120.def.in
+index 6db27845a..823b8f766 100644
+--- a/mingw-w64-crt/lib32/msvcr120.def.in
++++ b/mingw-w64-crt/lib32/msvcr120.def.in
+@@ -974,7 +974,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1961,7 +1961,7 @@ erfcf
+ erfcl
+ erff
+ erfl
+-exit
++exit DATA
+ exp
+ exp2
+ exp2f
+diff --git a/mingw-w64-crt/lib32/msvcr120d.def.in b/mingw-w64-crt/lib32/msvcr120d.def.in
+index 5ff03bda2..e83f1ee82 100644
+--- a/mingw-w64-crt/lib32/msvcr120d.def.in
++++ b/mingw-w64-crt/lib32/msvcr120d.def.in
+@@ -1027,7 +1027,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _expand_dbg
+ _fclose_nolock
+@@ -2028,7 +2028,7 @@ erfcf
+ erfcl
+ erff
+ erfl
+-exit
++exit DATA
+ exp
+ exp2
+ exp2f
+diff --git a/mingw-w64-crt/lib32/msvcr70.def.in b/mingw-w64-crt/lib32/msvcr70.def.in
+index 59f6ce2df..91d0b0f21 100644
+--- a/mingw-w64-crt/lib32/msvcr70.def.in
++++ b/mingw-w64-crt/lib32/msvcr70.def.in
+@@ -316,7 +316,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -731,7 +731,7 @@ cosh
+ ctime
+ difftime
+ div
+-exit
++exit DATA
+ exp
+ fabs
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcr71.def.in b/mingw-w64-crt/lib32/msvcr71.def.in
+index 1da46dcdf..2f83a442d 100644
+--- a/mingw-w64-crt/lib32/msvcr71.def.in
++++ b/mingw-w64-crt/lib32/msvcr71.def.in
+@@ -309,7 +309,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -726,7 +726,7 @@ cosh
+ ctime
+ difftime
+ div
+-exit
++exit DATA
+ exp
+ fabs
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcr80.def.in b/mingw-w64-crt/lib32/msvcr80.def.in
+index e0d8ad569..02beecfd9 100644
+--- a/mingw-w64-crt/lib32/msvcr80.def.in
++++ b/mingw-w64-crt/lib32/msvcr80.def.in
+@@ -164,7 +164,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -592,7 +592,7 @@ _ctime32
+ ctime == _ctime32
+ difftime
+ div
+-exit
++exit DATA
+ exp DATA
+ fabs DATA
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcr90.def.in b/mingw-w64-crt/lib32/msvcr90.def.in
+index 4424adfe5..ffcaeb10c 100644
+--- a/mingw-w64-crt/lib32/msvcr90.def.in
++++ b/mingw-w64-crt/lib32/msvcr90.def.in
+@@ -463,7 +463,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1342,7 +1342,7 @@ cos DATA
+ ; If we have cosh implementation, we can set it to DATA only.
+ cosh
+ div
+-exit
++exit DATA
+ exp DATA
+ fabs DATA
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcr90d.def.in b/mingw-w64-crt/lib32/msvcr90d.def.in
+index 2835301f0..23080dbc5 100644
+--- a/mingw-w64-crt/lib32/msvcr90d.def.in
++++ b/mingw-w64-crt/lib32/msvcr90d.def.in
+@@ -520,7 +520,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _expand_dbg
+ _fclose_nolock
+@@ -1414,7 +1414,7 @@ cos DATA
+ ; If we implement cosh too, we can set it to DATA only.
+ cosh
+ div
+-exit
++exit DATA
+ exp DATA
+ fabs DATA
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcrt10.def.in b/mingw-w64-crt/lib32/msvcrt10.def.in
+index af82d7fd5..c94fb6c94 100644
+--- a/mingw-w64-crt/lib32/msvcrt10.def.in
++++ b/mingw-w64-crt/lib32/msvcrt10.def.in
+@@ -946,7 +946,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -1129,7 +1129,7 @@ cosh
+ ctime
+ difftime
+ div
+-exit
++exit DATA
+ exp
+ fabs
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcrt20.def.in b/mingw-w64-crt/lib32/msvcrt20.def.in
+index 1ad59beb9..c4b1f2f53 100644
+--- a/mingw-w64-crt/lib32/msvcrt20.def.in
++++ b/mingw-w64-crt/lib32/msvcrt20.def.in
+@@ -1016,7 +1016,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -1397,7 +1397,7 @@ cosh
+ ctime
+ difftime
+ div
+-exit
++exit DATA
+ exp
+ fabs
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcrt40.def.in b/mingw-w64-crt/lib32/msvcrt40.def.in
+index 03094dce8..a09b51428 100644
+--- a/mingw-w64-crt/lib32/msvcrt40.def.in
++++ b/mingw-w64-crt/lib32/msvcrt40.def.in
+@@ -1115,7 +1115,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -1481,7 +1481,7 @@ cosh
+ ctime
+ difftime
+ div
+-exit
++exit DATA
+ exp
+ fabs
+ fclose
+diff --git a/mingw-w64-crt/lib64/msvcr100.def.in b/mingw-w64-crt/lib64/msvcr100.def.in
+index 1c72309d4..eef42c929 100644
+--- a/mingw-w64-crt/lib64/msvcr100.def.in
++++ b/mingw-w64-crt/lib64/msvcr100.def.in
+@@ -789,7 +789,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1657,7 +1657,7 @@ cosf DATA
+ cosh
+ coshf DATA
+ div
+-exit
++exit DATA
+ exp DATA
+ expf DATA
+ fabs DATA
+diff --git a/mingw-w64-crt/lib64/msvcr110.def.in b/mingw-w64-crt/lib64/msvcr110.def.in
+index f3fc9a25b..06507883d 100644
+--- a/mingw-w64-crt/lib64/msvcr110.def.in
++++ b/mingw-w64-crt/lib64/msvcr110.def.in
+@@ -914,7 +914,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1781,7 +1781,7 @@ cosf
+ cosh
+ coshf
+ div
+-exit
++exit DATA
+ exp
+ expf
+ fabs
+diff --git a/mingw-w64-crt/lib64/msvcr120.def.in b/mingw-w64-crt/lib64/msvcr120.def.in
+index 8c6dd5dd6..13d7ae262 100644
+--- a/mingw-w64-crt/lib64/msvcr120.def.in
++++ b/mingw-w64-crt/lib64/msvcr120.def.in
+@@ -928,7 +928,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1906,7 +1906,7 @@ erfcf
+ erfcl
+ erff
+ erfl
+-exit
++exit DATA
+ exp
+ exp2
+ exp2f
+diff --git a/mingw-w64-crt/lib64/msvcr120d.def.in b/mingw-w64-crt/lib64/msvcr120d.def.in
+index dca76d1e8..8080f5e5c 100644
+--- a/mingw-w64-crt/lib64/msvcr120d.def.in
++++ b/mingw-w64-crt/lib64/msvcr120d.def.in
+@@ -979,7 +979,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _expand_dbg
+ _fclose_nolock
+@@ -1970,7 +1970,7 @@ erfcf
+ erfcl
+ erff
+ erfl
+-exit
++exit DATA
+ exp
+ exp2
+ exp2f
+diff --git a/mingw-w64-crt/lib64/msvcr80.def.in b/mingw-w64-crt/lib64/msvcr80.def.in
+index 16a6b57c0..ab13a5471 100644
+--- a/mingw-w64-crt/lib64/msvcr80.def.in
++++ b/mingw-w64-crt/lib64/msvcr80.def.in
+@@ -254,7 +254,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -723,7 +723,7 @@ coshf
+ _ctime32
+ difftime
+ div
+-exit
++exit DATA
+ exp DATA
+ expf DATA
+ fabs
+diff --git a/mingw-w64-crt/lib64/msvcr90.def.in b/mingw-w64-crt/lib64/msvcr90.def.in
+index 1ffd75541..b785753ee 100644
+--- a/mingw-w64-crt/lib64/msvcr90.def.in
++++ b/mingw-w64-crt/lib64/msvcr90.def.in
+@@ -408,7 +408,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1281,7 +1281,7 @@ cosf DATA
+ cosh
+ coshf DATA
+ div
+-exit
++exit DATA
+ exp DATA
+ expf DATA
+ fabs DATA
+diff --git a/mingw-w64-crt/lib64/msvcr90d.def.in b/mingw-w64-crt/lib64/msvcr90d.def.in
+index 07adb60dd..a1d5de3aa 100644
+--- a/mingw-w64-crt/lib64/msvcr90d.def.in
++++ b/mingw-w64-crt/lib64/msvcr90d.def.in
+@@ -459,7 +459,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _expand_dbg
+ _fclose_nolock
+@@ -1347,7 +1347,7 @@ cosf
+ cosh
+ coshf
+ div
+-exit
++exit DATA
+ exp DATA
+ expf DATA
+ fabs
+diff --git a/mingw-w64-crt/libarm32/kernelbase.def b/mingw-w64-crt/libarm32/kernelbase.def
+index d6a487db1..f6626c5df 100644
+--- a/mingw-w64-crt/libarm32/kernelbase.def
++++ b/mingw-w64-crt/libarm32/kernelbase.def
+@@ -1882,7 +1882,7 @@ __wgetmainargs
+ _amsg_exit
+ _c_exit
+ _cexit
+-_exit
++_exit DATA
+ _initterm
+ _initterm_e
+ _invalid_parameter
+@@ -1890,7 +1890,7 @@ _onexit
+ _purecall
+ _time64
+ atexit DATA
+-exit
++exit DATA
+ hgets
+ hwprintf
+ lstrcmp
+diff --git a/mingw-w64-crt/libarm32/msvcr110.def b/mingw-w64-crt/libarm32/msvcr110.def
+index 0c4aa92af..f5f31d232 100644
+--- a/mingw-w64-crt/libarm32/msvcr110.def
++++ b/mingw-w64-crt/libarm32/msvcr110.def
+@@ -574,7 +574,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1410,7 +1410,7 @@ cosf
+ cosh
+ coshf
+ div
+-exit
++exit DATA
+ exp
+ expf
+ fabs
+diff --git a/mingw-w64-crt/libarm32/msvcr120_clr0400.def b/mingw-w64-crt/libarm32/msvcr120_clr0400.def
+index 3a153da53..18ab94522 100644
+--- a/mingw-w64-crt/libarm32/msvcr120_clr0400.def
++++ b/mingw-w64-crt/libarm32/msvcr120_clr0400.def
+@@ -573,7 +573,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1409,7 +1409,7 @@ cosf
+ cosh
+ coshf
+ div
+-exit
++exit DATA
+ exp
+ expf
+ fabs
+-- 
+2.41.0
+

--- a/patches/mingw-w64/9002-v11-crt-Provide-wrappers-for-exit-in-libmingwex.patch
+++ b/patches/mingw-w64/9002-v11-crt-Provide-wrappers-for-exit-in-libmingwex.patch
@@ -1,0 +1,772 @@
+From 1b5b977ce3da8eb210dccf7ca7a00781eb438c03 Mon Sep 17 00:00:00 2001
+From: LIU Hao <lh_mouse@126.com>
+Date: Fri, 7 Oct 2022 22:46:50 +0800
+Subject: [PATCH 2/3] crt: Provide wrappers for `*exit()` in libmingwex
+
+This should have no effect on functionality, but allows further
+customization of them.
+
+Signed-off-by: LIU Hao <lh_mouse@126.com>
+---
+ mingw-w64-crt/Makefile.am                     |  2 +-
+ mingw-w64-crt/crt/exit_wrappers.c             | 25 +++++++++++++++++
+ mingw-w64-crt/crt/ucrt_exit_wrappers.c        | 27 +++++++++++++++++++
+ mingw-w64-crt/crt/ucrtbase_compat.c           |  4 ++-
+ .../api-ms-win-crt-runtime-l1-1-0.def.in      |  8 +++---
+ mingw-w64-crt/lib-common/msvcr120_app.def.in  |  4 +--
+ mingw-w64-crt/lib-common/msvcrt.def.in        |  4 +--
+ mingw-w64-crt/lib-common/ucrtbase.def.in      |  8 +++---
+ mingw-w64-crt/lib32/crtdll.def.in             |  4 +--
+ mingw-w64-crt/lib32/msvcr100.def.in           |  4 +--
+ mingw-w64-crt/lib32/msvcr110.def.in           |  4 +--
+ mingw-w64-crt/lib32/msvcr120.def.in           |  4 +--
+ mingw-w64-crt/lib32/msvcr120d.def.in          |  4 +--
+ mingw-w64-crt/lib32/msvcr70.def.in            |  4 +--
+ mingw-w64-crt/lib32/msvcr71.def.in            |  4 +--
+ mingw-w64-crt/lib32/msvcr80.def.in            |  4 +--
+ mingw-w64-crt/lib32/msvcr90.def.in            |  4 +--
+ mingw-w64-crt/lib32/msvcr90d.def.in           |  4 +--
+ mingw-w64-crt/lib32/msvcrt10.def.in           |  4 +--
+ mingw-w64-crt/lib32/msvcrt20.def.in           |  4 +--
+ mingw-w64-crt/lib32/msvcrt40.def.in           |  4 +--
+ mingw-w64-crt/lib64/msvcr100.def.in           |  4 +--
+ mingw-w64-crt/lib64/msvcr110.def.in           |  4 +--
+ mingw-w64-crt/lib64/msvcr120.def.in           |  4 +--
+ mingw-w64-crt/lib64/msvcr120d.def.in          |  4 +--
+ mingw-w64-crt/lib64/msvcr80.def.in            |  4 +--
+ mingw-w64-crt/lib64/msvcr90.def.in            |  4 +--
+ mingw-w64-crt/lib64/msvcr90d.def.in           |  4 +--
+ mingw-w64-crt/libarm32/kernelbase.def         |  4 +--
+ mingw-w64-crt/libarm32/msvcr110.def           |  4 +--
+ mingw-w64-crt/libarm32/msvcr120_clr0400.def   |  4 +--
+ 31 files changed, 114 insertions(+), 60 deletions(-)
+ create mode 100644 mingw-w64-crt/crt/exit_wrappers.c
+ create mode 100644 mingw-w64-crt/crt/ucrt_exit_wrappers.c
+
+diff --git a/mingw-w64-crt/Makefile.am b/mingw-w64-crt/Makefile.am
+index 0454ecec3..666415857 100644
+--- a/mingw-w64-crt/Makefile.am
++++ b/mingw-w64-crt/Makefile.am
+@@ -129,7 +129,7 @@ src_libmingw32=include/oscalls.h include/internal.h include/sect_attribs.h \
+   crt/usermatherr.c   \
+   crt/xtxtmode.c      crt/crt_handler.c    \
+   crt/tlsthrd.c       crt/tlsmthread.c     crt/tlsmcrt.c   \
+-  crt/cxa_atexit.c    crt/cxa_thread_atexit.c crt/tls_atexit.c
++  crt/cxa_atexit.c    crt/cxa_thread_atexit.c   crt/tls_atexit.c   crt/exit_wrappers.c   crt/ucrt_exit_wrappers.c
+ 
+ src_libscrnsave=libsrc/scrnsave.c
+ src_libscrnsavw=libsrc/scrnsave.c
+diff --git a/mingw-w64-crt/crt/exit_wrappers.c b/mingw-w64-crt/crt/exit_wrappers.c
+new file mode 100644
+index 000000000..256c26d07
+--- /dev/null
++++ b/mingw-w64-crt/crt/exit_wrappers.c
+@@ -0,0 +1,25 @@
++/**
++ * This file has no copyright assigned and is placed in the Public Domain.
++ * This file is part of the mingw-w64 runtime package.
++ * No warranty is given; refer to the file DISCLAIMER.PD within this package.
++ */
++
++#include <_mingw.h>
++
++/* `exit()`, C89  */
++void exit(int status) __attribute__((__noreturn__));
++extern void (*__MINGW_IMP_SYMBOL(exit))(int) __attribute__((__noreturn__));
++
++void exit(int status)
++{
++  (*__MINGW_IMP_SYMBOL(exit))(status);
++}
++
++/* `_exit()`, POSIX  */
++void _exit(int status) __attribute__((__noreturn__));
++extern void (*__MINGW_IMP_SYMBOL(_exit))(int) __attribute__((__noreturn__));
++
++void _exit(int status)
++{
++  (*__MINGW_IMP_SYMBOL(_exit))(status);
++}
+diff --git a/mingw-w64-crt/crt/ucrt_exit_wrappers.c b/mingw-w64-crt/crt/ucrt_exit_wrappers.c
+new file mode 100644
+index 000000000..112d8e3c7
+--- /dev/null
++++ b/mingw-w64-crt/crt/ucrt_exit_wrappers.c
+@@ -0,0 +1,27 @@
++/**
++ * This file has no copyright assigned and is placed in the Public Domain.
++ * This file is part of the mingw-w64 runtime package.
++ * No warranty is given; refer to the file DISCLAIMER.PD within this package.
++ */
++
++#undef __MSVCRT_VERSION__
++#define _UCRT
++#include <_mingw.h>
++
++/* `quick_exit()`, C99  */
++void quick_exit(int status) __attribute__((__noreturn__));
++extern void (*__MINGW_IMP_SYMBOL(quick_exit))(int) __attribute__((__noreturn__));
++
++void quick_exit(int status)
++{
++  (*__MINGW_IMP_SYMBOL(quick_exit))(status);
++}
++
++/* `_Exit()`, C99  */
++void _Exit(int status) __attribute__((__noreturn__));
++extern void (*__MINGW_IMP_SYMBOL(_Exit))(int) __attribute__((__noreturn__));
++
++void _Exit(int status)
++{
++  (*__MINGW_IMP_SYMBOL(_Exit))(status);
++}
+diff --git a/mingw-w64-crt/crt/ucrtbase_compat.c b/mingw-w64-crt/crt/ucrtbase_compat.c
+index 33eeaff3e..3f88d24c4 100644
+--- a/mingw-w64-crt/crt/ucrtbase_compat.c
++++ b/mingw-w64-crt/crt/ucrtbase_compat.c
+@@ -102,9 +102,11 @@ int __cdecl at_quick_exit(void (__cdecl *func)(void))
+ 
+ int __cdecl (*__MINGW_IMP_SYMBOL(at_quick_exit))(void (__cdecl *)(void)) = at_quick_exit;
+ 
++extern void (*__MINGW_IMP_SYMBOL(_exit))(int) __attribute__((__noreturn__));
++
+ void __cdecl _amsg_exit(int ret) {
+   fprintf(stderr, "runtime error %d\n", ret);
+-  _exit(255);
++  (*__MINGW_IMP_SYMBOL(_exit))(255);
+ }
+ 
+ unsigned int __cdecl _get_output_format(void)
+diff --git a/mingw-w64-crt/lib-common/api-ms-win-crt-runtime-l1-1-0.def.in b/mingw-w64-crt/lib-common/api-ms-win-crt-runtime-l1-1-0.def.in
+index ea310d426..33e4f5504 100644
+--- a/mingw-w64-crt/lib-common/api-ms-win-crt-runtime-l1-1-0.def.in
++++ b/mingw-w64-crt/lib-common/api-ms-win-crt-runtime-l1-1-0.def.in
+@@ -4,7 +4,7 @@ EXPORTS
+ 
+ #include "func.def.in"
+ 
+-_Exit
++_Exit DATA
+ F_I386(__control87_2)
+ __doserrno
+ __fpe_flt_rounds
+@@ -42,7 +42,7 @@ _endthread
+ _endthreadex
+ _errno
+ _execute_onexit_table
+-_exit
++_exit DATA
+ F_NON_I386(_fpieee_flt)
+ ; DATA added manually
+ _fpreset DATA
+@@ -96,7 +96,7 @@ _wcserror_s
+ _wperror
+ _wsystem
+ abort
+-exit
++exit DATA
+ ; Don't use the float env functions from UCRT; fesetround doesn't seem to have
+ ; any effect on the FPU control word as required by other libmingwex math
+ ; routines.
+@@ -110,7 +110,7 @@ fesetexceptflag DATA
+ fesetround DATA
+ fetestexcept DATA
+ perror
+-quick_exit
++quick_exit DATA
+ raise
+ set_terminate
+ signal
+diff --git a/mingw-w64-crt/lib-common/msvcr120_app.def.in b/mingw-w64-crt/lib-common/msvcr120_app.def.in
+index ddb407d00..33f2e9345 100644
+--- a/mingw-w64-crt/lib-common/msvcr120_app.def.in
++++ b/mingw-w64-crt/lib-common/msvcr120_app.def.in
+@@ -1080,7 +1080,7 @@ F_ARM32(_execv)
+ F_ARM32(_execve)
+ F_ARM32(_execvp)
+ F_ARM32(_execvpe)
+-_exit
++_exit DATA
+ F_X86_ANY(_exit_app)
+ _expand
+ F_X86_ANY(_fclose_nolock)
+@@ -2143,7 +2143,7 @@ erfcl
+ erff
+ erfl
+ #endif
+-exit
++exit DATA
+ exp
+ exp2
+ exp2f
+diff --git a/mingw-w64-crt/lib-common/msvcrt.def.in b/mingw-w64-crt/lib-common/msvcrt.def.in
+index 1f8f95b17..255080a2e 100644
+--- a/mingw-w64-crt/lib-common/msvcrt.def.in
++++ b/mingw-w64-crt/lib-common/msvcrt.def.in
+@@ -485,7 +485,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ F_ARM_ANY(_expand_dbg)
+ _fcloseall
+@@ -1356,7 +1356,7 @@ F_NON_I386(coshf DATA)
+ ctime
+ difftime
+ div
+-exit
++exit DATA
+ exp F_X86_ANY(DATA)
+ F_NON_I386(expf F_X86_ANY(DATA))
+ F_ARM_ANY(expl == exp)
+diff --git a/mingw-w64-crt/lib-common/ucrtbase.def.in b/mingw-w64-crt/lib-common/ucrtbase.def.in
+index 0b83b04e7..3fb041727 100644
+--- a/mingw-w64-crt/lib-common/ucrtbase.def.in
++++ b/mingw-w64-crt/lib-common/ucrtbase.def.in
+@@ -30,7 +30,7 @@ _CreateFrameInfo
+ F_I386(_CxxThrowException@8)
+ F_NON_I386(_CxxThrowException)
+ F_I386(_EH_prolog)
+-_Exit
++_Exit DATA
+ _FCbuild
+ _FCmulcc
+ _FCmulcr
+@@ -299,7 +299,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -2305,7 +2305,7 @@ erfcf
+ erfcl F_X86_ANY(DATA)
+ erff
+ erfl F_X86_ANY(DATA)
+-exit
++exit DATA
+ exp F_X86_ANY(DATA)
+ exp2
+ exp2f
+@@ -2501,7 +2501,7 @@ putwc
+ putwchar
+ qsort
+ qsort_s
+-quick_exit
++quick_exit DATA
+ raise
+ rand
+ rand_s
+diff --git a/mingw-w64-crt/lib32/crtdll.def.in b/mingw-w64-crt/lib32/crtdll.def.in
+index d8b5bd821..b5c99d4af 100644
+--- a/mingw-w64-crt/lib32/crtdll.def.in
++++ b/mingw-w64-crt/lib32/crtdll.def.in
+@@ -269,7 +269,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -552,7 +552,7 @@ ctime DATA
+ ;_ctime32 = ctime
+ difftime
+ div
+-exit
++exit DATA
+ exp DATA
+ fabs DATA
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcr100.def.in b/mingw-w64-crt/lib32/msvcr100.def.in
+index e2e0e18c7..d86f5f5b2 100644
+--- a/mingw-w64-crt/lib32/msvcr100.def.in
++++ b/mingw-w64-crt/lib32/msvcr100.def.in
+@@ -834,7 +834,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1704,7 +1704,7 @@ cos DATA
+ ; If we implement cosh too, we can set it to DATA only.
+ cosh
+ div
+-exit
++exit DATA
+ exp DATA
+ fabs DATA
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcr110.def.in b/mingw-w64-crt/lib32/msvcr110.def.in
+index 2045e0a54..bf4979031 100644
+--- a/mingw-w64-crt/lib32/msvcr110.def.in
++++ b/mingw-w64-crt/lib32/msvcr110.def.in
+@@ -957,7 +957,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1837,7 +1837,7 @@ cos DATA
+ ; If we implement cosh, we can set it to DATA only.
+ cosh
+ div
+-exit
++exit DATA
+ exp DATA
+ fabs DATA
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcr120.def.in b/mingw-w64-crt/lib32/msvcr120.def.in
+index 6db27845a..823b8f766 100644
+--- a/mingw-w64-crt/lib32/msvcr120.def.in
++++ b/mingw-w64-crt/lib32/msvcr120.def.in
+@@ -974,7 +974,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1961,7 +1961,7 @@ erfcf
+ erfcl
+ erff
+ erfl
+-exit
++exit DATA
+ exp
+ exp2
+ exp2f
+diff --git a/mingw-w64-crt/lib32/msvcr120d.def.in b/mingw-w64-crt/lib32/msvcr120d.def.in
+index 5ff03bda2..e83f1ee82 100644
+--- a/mingw-w64-crt/lib32/msvcr120d.def.in
++++ b/mingw-w64-crt/lib32/msvcr120d.def.in
+@@ -1027,7 +1027,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _expand_dbg
+ _fclose_nolock
+@@ -2028,7 +2028,7 @@ erfcf
+ erfcl
+ erff
+ erfl
+-exit
++exit DATA
+ exp
+ exp2
+ exp2f
+diff --git a/mingw-w64-crt/lib32/msvcr70.def.in b/mingw-w64-crt/lib32/msvcr70.def.in
+index 59f6ce2df..91d0b0f21 100644
+--- a/mingw-w64-crt/lib32/msvcr70.def.in
++++ b/mingw-w64-crt/lib32/msvcr70.def.in
+@@ -316,7 +316,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -731,7 +731,7 @@ cosh
+ ctime
+ difftime
+ div
+-exit
++exit DATA
+ exp
+ fabs
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcr71.def.in b/mingw-w64-crt/lib32/msvcr71.def.in
+index 1da46dcdf..2f83a442d 100644
+--- a/mingw-w64-crt/lib32/msvcr71.def.in
++++ b/mingw-w64-crt/lib32/msvcr71.def.in
+@@ -309,7 +309,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -726,7 +726,7 @@ cosh
+ ctime
+ difftime
+ div
+-exit
++exit DATA
+ exp
+ fabs
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcr80.def.in b/mingw-w64-crt/lib32/msvcr80.def.in
+index e0d8ad569..02beecfd9 100644
+--- a/mingw-w64-crt/lib32/msvcr80.def.in
++++ b/mingw-w64-crt/lib32/msvcr80.def.in
+@@ -164,7 +164,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -592,7 +592,7 @@ _ctime32
+ ctime == _ctime32
+ difftime
+ div
+-exit
++exit DATA
+ exp DATA
+ fabs DATA
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcr90.def.in b/mingw-w64-crt/lib32/msvcr90.def.in
+index 4424adfe5..ffcaeb10c 100644
+--- a/mingw-w64-crt/lib32/msvcr90.def.in
++++ b/mingw-w64-crt/lib32/msvcr90.def.in
+@@ -463,7 +463,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1342,7 +1342,7 @@ cos DATA
+ ; If we have cosh implementation, we can set it to DATA only.
+ cosh
+ div
+-exit
++exit DATA
+ exp DATA
+ fabs DATA
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcr90d.def.in b/mingw-w64-crt/lib32/msvcr90d.def.in
+index 2835301f0..23080dbc5 100644
+--- a/mingw-w64-crt/lib32/msvcr90d.def.in
++++ b/mingw-w64-crt/lib32/msvcr90d.def.in
+@@ -520,7 +520,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _expand_dbg
+ _fclose_nolock
+@@ -1414,7 +1414,7 @@ cos DATA
+ ; If we implement cosh too, we can set it to DATA only.
+ cosh
+ div
+-exit
++exit DATA
+ exp DATA
+ fabs DATA
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcrt10.def.in b/mingw-w64-crt/lib32/msvcrt10.def.in
+index af82d7fd5..c94fb6c94 100644
+--- a/mingw-w64-crt/lib32/msvcrt10.def.in
++++ b/mingw-w64-crt/lib32/msvcrt10.def.in
+@@ -946,7 +946,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -1129,7 +1129,7 @@ cosh
+ ctime
+ difftime
+ div
+-exit
++exit DATA
+ exp
+ fabs
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcrt20.def.in b/mingw-w64-crt/lib32/msvcrt20.def.in
+index 1ad59beb9..c4b1f2f53 100644
+--- a/mingw-w64-crt/lib32/msvcrt20.def.in
++++ b/mingw-w64-crt/lib32/msvcrt20.def.in
+@@ -1016,7 +1016,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -1397,7 +1397,7 @@ cosh
+ ctime
+ difftime
+ div
+-exit
++exit DATA
+ exp
+ fabs
+ fclose
+diff --git a/mingw-w64-crt/lib32/msvcrt40.def.in b/mingw-w64-crt/lib32/msvcrt40.def.in
+index 03094dce8..a09b51428 100644
+--- a/mingw-w64-crt/lib32/msvcrt40.def.in
++++ b/mingw-w64-crt/lib32/msvcrt40.def.in
+@@ -1115,7 +1115,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -1481,7 +1481,7 @@ cosh
+ ctime
+ difftime
+ div
+-exit
++exit DATA
+ exp
+ fabs
+ fclose
+diff --git a/mingw-w64-crt/lib64/msvcr100.def.in b/mingw-w64-crt/lib64/msvcr100.def.in
+index 1c72309d4..eef42c929 100644
+--- a/mingw-w64-crt/lib64/msvcr100.def.in
++++ b/mingw-w64-crt/lib64/msvcr100.def.in
+@@ -789,7 +789,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1657,7 +1657,7 @@ cosf DATA
+ cosh
+ coshf DATA
+ div
+-exit
++exit DATA
+ exp DATA
+ expf DATA
+ fabs DATA
+diff --git a/mingw-w64-crt/lib64/msvcr110.def.in b/mingw-w64-crt/lib64/msvcr110.def.in
+index f3fc9a25b..06507883d 100644
+--- a/mingw-w64-crt/lib64/msvcr110.def.in
++++ b/mingw-w64-crt/lib64/msvcr110.def.in
+@@ -914,7 +914,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1781,7 +1781,7 @@ cosf
+ cosh
+ coshf
+ div
+-exit
++exit DATA
+ exp
+ expf
+ fabs
+diff --git a/mingw-w64-crt/lib64/msvcr120.def.in b/mingw-w64-crt/lib64/msvcr120.def.in
+index 8c6dd5dd6..13d7ae262 100644
+--- a/mingw-w64-crt/lib64/msvcr120.def.in
++++ b/mingw-w64-crt/lib64/msvcr120.def.in
+@@ -928,7 +928,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1906,7 +1906,7 @@ erfcf
+ erfcl
+ erff
+ erfl
+-exit
++exit DATA
+ exp
+ exp2
+ exp2f
+diff --git a/mingw-w64-crt/lib64/msvcr120d.def.in b/mingw-w64-crt/lib64/msvcr120d.def.in
+index dca76d1e8..8080f5e5c 100644
+--- a/mingw-w64-crt/lib64/msvcr120d.def.in
++++ b/mingw-w64-crt/lib64/msvcr120d.def.in
+@@ -979,7 +979,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _expand_dbg
+ _fclose_nolock
+@@ -1970,7 +1970,7 @@ erfcf
+ erfcl
+ erff
+ erfl
+-exit
++exit DATA
+ exp
+ exp2
+ exp2f
+diff --git a/mingw-w64-crt/lib64/msvcr80.def.in b/mingw-w64-crt/lib64/msvcr80.def.in
+index 16a6b57c0..ab13a5471 100644
+--- a/mingw-w64-crt/lib64/msvcr80.def.in
++++ b/mingw-w64-crt/lib64/msvcr80.def.in
+@@ -254,7 +254,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fcloseall
+ _fcvt
+@@ -723,7 +723,7 @@ coshf
+ _ctime32
+ difftime
+ div
+-exit
++exit DATA
+ exp DATA
+ expf DATA
+ fabs
+diff --git a/mingw-w64-crt/lib64/msvcr90.def.in b/mingw-w64-crt/lib64/msvcr90.def.in
+index 1ffd75541..b785753ee 100644
+--- a/mingw-w64-crt/lib64/msvcr90.def.in
++++ b/mingw-w64-crt/lib64/msvcr90.def.in
+@@ -408,7 +408,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1281,7 +1281,7 @@ cosf DATA
+ cosh
+ coshf DATA
+ div
+-exit
++exit DATA
+ exp DATA
+ expf DATA
+ fabs DATA
+diff --git a/mingw-w64-crt/lib64/msvcr90d.def.in b/mingw-w64-crt/lib64/msvcr90d.def.in
+index 07adb60dd..a1d5de3aa 100644
+--- a/mingw-w64-crt/lib64/msvcr90d.def.in
++++ b/mingw-w64-crt/lib64/msvcr90d.def.in
+@@ -459,7 +459,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _expand_dbg
+ _fclose_nolock
+@@ -1347,7 +1347,7 @@ cosf
+ cosh
+ coshf
+ div
+-exit
++exit DATA
+ exp DATA
+ expf DATA
+ fabs
+diff --git a/mingw-w64-crt/libarm32/kernelbase.def b/mingw-w64-crt/libarm32/kernelbase.def
+index d6a487db1..f6626c5df 100644
+--- a/mingw-w64-crt/libarm32/kernelbase.def
++++ b/mingw-w64-crt/libarm32/kernelbase.def
+@@ -1882,7 +1882,7 @@ __wgetmainargs
+ _amsg_exit
+ _c_exit
+ _cexit
+-_exit
++_exit DATA
+ _initterm
+ _initterm_e
+ _invalid_parameter
+@@ -1890,7 +1890,7 @@ _onexit
+ _purecall
+ _time64
+ atexit DATA
+-exit
++exit DATA
+ hgets
+ hwprintf
+ lstrcmp
+diff --git a/mingw-w64-crt/libarm32/msvcr110.def b/mingw-w64-crt/libarm32/msvcr110.def
+index 0c4aa92af..f5f31d232 100644
+--- a/mingw-w64-crt/libarm32/msvcr110.def
++++ b/mingw-w64-crt/libarm32/msvcr110.def
+@@ -574,7 +574,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1410,7 +1410,7 @@ cosf
+ cosh
+ coshf
+ div
+-exit
++exit DATA
+ exp
+ expf
+ fabs
+diff --git a/mingw-w64-crt/libarm32/msvcr120_clr0400.def b/mingw-w64-crt/libarm32/msvcr120_clr0400.def
+index 3a153da53..18ab94522 100644
+--- a/mingw-w64-crt/libarm32/msvcr120_clr0400.def
++++ b/mingw-w64-crt/libarm32/msvcr120_clr0400.def
+@@ -573,7 +573,7 @@ _execv
+ _execve
+ _execvp
+ _execvpe
+-_exit
++_exit DATA
+ _expand
+ _fclose_nolock
+ _fcloseall
+@@ -1409,7 +1409,7 @@ cosf
+ cosh
+ coshf
+ div
+-exit
++exit DATA
+ exp
+ expf
+ fabs
+-- 
+2.42.0.windows.2
+

--- a/patches/mingw-w64/9003-crt-Implement-standard-conforming-termination-suppor.patch
+++ b/patches/mingw-w64/9003-crt-Implement-standard-conforming-termination-suppor.patch
@@ -1,0 +1,329 @@
+From fb2ac382e29f407014f8ff8ad5de6698d342e0da Mon Sep 17 00:00:00 2001
+From: LIU Hao <lh_mouse@126.com>
+Date: Sat, 22 Oct 2022 23:31:33 +0800
+Subject: [PATCH 4/5] crt: Implement standard-conforming termination support
+ with mcfgthread
+
+This commit implements these functions in accordance with the ISO C
+standard and the Itanium C++ ABI (except for `atexit()` which behaves
+in a per-module way like its old behavior, and also on Linux):
+
+  * `atexit()`, C89
+  * `exit()`, C89
+  * `__cxa_atexit()`, Itanium C++ ABI
+  * `_exit()`, POSIX
+  * `_Exit()`, C99
+  * `at_quick_exit()`, C99
+  * `quick_exit()`, C99
+  * `__cxa_at_quick_exit()`, GNU extension
+
+Implementation details:
+
+  1. An object with the name `__dso_handle` is defined for each
+     module (EXE or DLL).
+  2. Per-module cleanup callbacks should be registered with
+     `__MCF_cxa_atexit()` or `__MCF_cxa_at_quick_exit()`, passing
+     `&__dso_handle` as its third argument.
+  3. When a process calls `exit()` or returns from `main()`,
+     `__MCF_cxa_finalize(NULL)` is called, which executes all
+     callbacks registered with `__MCF_cxa_atexit()` in reverse
+     order.
+  4. When a DLL is unloaded neither by calling `exit()` nor by
+     returning from `main()` (in other words, by `FreeLibrary()`),
+     `__MCF_cxa_finalize(&__dso_handle)`, which executes all
+     callbacks registered with `__MCF_cxa_atexit()` with the same
+     DSO handle in reverse order. Callbacks that have been
+     registered with `__MCF_cxa_at_quick_exit()` are deleted.
+  5. All standard I/O streams are flushed before the process
+     terminates.
+
+Signed-off-by: LIU Hao <lh_mouse@126.com>
+---
+ mingw-w64-crt/crt/crtdll.c             | 29 ++++++++++++++++++++++++-
+ mingw-w64-crt/crt/crtexe.c             | 14 ++++++++++++
+ mingw-w64-crt/crt/exit_wrappers.c      | 26 ++++++++++++++++++++++
+ mingw-w64-crt/crt/tls_atexit.c         | 30 +++++++++++++++++++++-----
+ mingw-w64-crt/crt/ucrt_exit_wrappers.c |  8 +++++++
+ mingw-w64-crt/crt/ucrtbase_compat.c    |  7 ++++--
+ 6 files changed, 106 insertions(+), 8 deletions(-)
+
+diff --git a/mingw-w64-crt/crt/crtdll.c b/mingw-w64-crt/crt/crtdll.c
+index e264d4e96..768c0f44e 100644
+--- a/mingw-w64-crt/crt/crtdll.c
++++ b/mingw-w64-crt/crt/crtdll.c
+@@ -31,6 +31,12 @@
+ #endif
+ #include <sect_attribs.h>
+ #include <locale.h>
++#include <stdio.h>
++#ifdef __USING_MCFGTHREAD__
++#include <mcfgthread/cxa.h>
++#endif
++
++extern HANDLE __dso_handle;
+ 
+ extern void __cdecl _initterm(_PVFV *,_PVFV *);
+ extern void __main ();
+@@ -182,7 +188,14 @@ __DllMainCRTStartup (HANDLE hDllHandle, DWORD dwReason, LPVOID lpreserved)
+ 	  }
+     }
+   if (dwReason == DLL_PROCESS_ATTACH)
+-    __main ();
++    {
++#ifdef __USING_MCFGTHREAD__
++      /* Register `fflush(NULL)` before user-defined constructors, so
++       * it will be executed after all user-defined destructors.  */
++      __MCF_cxa_atexit ((__MCF_cxa_dtor_cdecl*)(intptr_t) fflush, NULL, &__dso_handle);
++#endif
++      __main ();
++    }
+   retcode = DllMain(hDllHandle,dwReason,lpreserved);
+   if (dwReason == DLL_PROCESS_ATTACH && ! retcode)
+     {
+@@ -196,6 +209,16 @@ __DllMainCRTStartup (HANDLE hDllHandle, DWORD dwReason, LPVOID lpreserved)
+ 	if (_CRT_INIT (hDllHandle, dwReason, lpreserved) == FALSE)
+ 	  retcode = FALSE;
+     }
++#ifdef __USING_MCFGTHREAD__
++  if (dwReason == DLL_PROCESS_DETACH && lpreserved == NULL)
++    {
++      /* Call `__cxa_finalize(dso_handle)` if the library is unloaded
++       * dynamically. This conforms to the Itanium C++ ABI. Note it is
++       * not called in case of process termination, where a call to
++       * `__cxa_finalize(NULL)` shall have been made instead.  */
++      __MCF_cxa_finalize (&__dso_handle);
++    }
++#endif
+ i__leave:
+   __native_dllmain_reason = UINT_MAX;
+   return retcode ;
+@@ -204,7 +227,11 @@ i__leave:
+ 
+ int __cdecl atexit (_PVFV func)
+ {
++#ifdef __USING_MCFGTHREAD__
++    return __MCF_cxa_atexit ((__MCF_cxa_dtor_cdecl*)(intptr_t) func, NULL, &__dso_handle);
++#else
+     return _register_onexit_function(&atexit_table, (_onexit_t)func);
++#endif
+ }
+ 
+ char __mingw_module_is_dll = 1;
+diff --git a/mingw-w64-crt/crt/crtexe.c b/mingw-w64-crt/crt/crtexe.c
+index 03bda5912..7f501400a 100644
+--- a/mingw-w64-crt/crt/crtexe.c
++++ b/mingw-w64-crt/crt/crtexe.c
+@@ -20,6 +20,10 @@
+ #include <tchar.h>
+ #include <sect_attribs.h>
+ #include <locale.h>
++#include <stdio.h>
++#ifdef __USING_MCFGTHREAD__
++#include <mcfgthread/cxa.h>
++#endif
+ 
+ #if defined(__SEH__) && (!defined(__clang__) || __clang_major__ >= 7)
+ #define SEH_INLINE_ASM
+@@ -45,6 +49,7 @@ int *__cdecl __p__commode(void);
+ extern int _fmode;
+ extern int _commode;
+ extern int _dowildcard;
++extern HANDLE __dso_handle;
+ 
+ extern _CRTIMP void __cdecl _initterm(_PVFV *, _PVFV *);
+ 
+@@ -258,6 +263,11 @@ __tmainCRTStartup (void)
+     _fpreset ();
+ 
+     duplicate_ppstrings (argc, &argv);
++#ifdef __USING_MCFGTHREAD__
++    /* Register `fflush(NULL)` before user-defined constructors, so
++     * it will be executed after all user-defined destructors.  */
++    __MCF_cxa_atexit ((__MCF_cxa_dtor_cdecl*)(intptr_t) fflush, NULL, &__dso_handle);
++#endif
+     __main (); /* C++ initialization. */
+ #ifdef _UNICODE
+     __winitenv = envp;
+@@ -334,7 +344,11 @@ static void duplicate_ppstrings (int ac, _TCHAR ***av)
+ 
+ int __cdecl atexit (_PVFV func)
+ {
++#ifdef __USING_MCFGTHREAD__
++    return __MCF_cxa_atexit ((__MCF_cxa_dtor_cdecl*)(intptr_t) func, NULL, &__dso_handle);
++#else
+     return _onexit((_onexit_t)func) ? 0 : -1;
++#endif
+ }
+ 
+ char __mingw_module_is_dll = 0;
+diff --git a/mingw-w64-crt/crt/exit_wrappers.c b/mingw-w64-crt/crt/exit_wrappers.c
+index 256c26d07..ab6896f96 100644
+--- a/mingw-w64-crt/crt/exit_wrappers.c
++++ b/mingw-w64-crt/crt/exit_wrappers.c
+@@ -5,6 +5,10 @@
+  */
+ 
+ #include <_mingw.h>
++#ifdef __USING_MCFGTHREAD__
++#include <mcfgthread/exit.h>
++#include <mcfgthread/cxa.h>
++#endif
+ 
+ /* `exit()`, C89  */
+ void exit(int status) __attribute__((__noreturn__));
+@@ -12,7 +16,11 @@ extern void (*__MINGW_IMP_SYMBOL(exit))(int) __attribute__((__noreturn__));
+ 
+ void exit(int status)
+ {
++#ifdef __USING_MCFGTHREAD__
++  __MCF_exit(status);
++#else
+   (*__MINGW_IMP_SYMBOL(exit))(status);
++#endif
+ }
+ 
+ /* `_exit()`, POSIX  */
+@@ -21,5 +29,23 @@ extern void (*__MINGW_IMP_SYMBOL(_exit))(int) __attribute__((__noreturn__));
+ 
+ void _exit(int status)
+ {
++#ifdef __USING_MCFGTHREAD__
++  __MCF__Exit(status);
++#else
+   (*__MINGW_IMP_SYMBOL(_exit))(status);
++#endif
+ }
++
++#ifdef __USING_MCFGTHREAD__
++/* `at_quick_exit()`, C99  */
++typedef void (__cdecl *_PVFV)(void);
++int at_quick_exit(_PVFV func);
++
++typedef void* HANDLE;
++extern HANDLE __dso_handle;
++
++int at_quick_exit(_PVFV func)
++{
++  return __MCF_cxa_at_quick_exit ((__MCF_cxa_dtor_cdecl*)(intptr_t) func, NULL, &__dso_handle);
++}
++#endif  /* __USING_MCFGTHREAD__  */
+diff --git a/mingw-w64-crt/crt/tls_atexit.c b/mingw-w64-crt/crt/tls_atexit.c
+index 0412fa4ba..ed36b935c 100644
+--- a/mingw-w64-crt/crt/tls_atexit.c
++++ b/mingw-w64-crt/crt/tls_atexit.c
+@@ -4,6 +4,29 @@
+  * No warranty is given; refer to the file DISCLAIMER.PD within this package.
+  */
+ 
++typedef void (__thiscall * dtor_fn)(void*);
++int __mingw_cxa_atexit(dtor_fn dtor, void *obj, void *dso);
++int __mingw_cxa_thread_atexit(dtor_fn dtor, void *obj, void *dso);
++
++/* This is the per-module DSO handle as required by Itanium ABI.  */
++void* __dso_handle;
++
++#ifdef __USING_MCFGTHREAD__
++
++#include <mcfgthread/cxa.h>
++
++int __mingw_cxa_atexit(dtor_fn dtor, void *obj, void *dso)
++{
++  return __MCF_cxa_atexit(dtor, obj, dso);
++}
++
++int __mingw_cxa_thread_atexit(dtor_fn dtor, void *obj, void *dso)
++{
++  return __MCF_cxa_thread_atexit(dtor, obj, dso);
++}
++
++#else  /* __USING_MCFGTHREAD__  */
++
+ #include <sect_attribs.h>
+ 
+ #ifndef WIN32_LEAN_AND_MEAN
+@@ -18,10 +41,6 @@
+ #include <process.h>
+ 
+ 
+-typedef void (__thiscall * dtor_fn)(void*);
+-int __mingw_cxa_atexit(dtor_fn dtor, void *obj, void *dso);
+-int __mingw_cxa_thread_atexit(dtor_fn dtor, void *obj, void *dso);
+-
+ typedef struct dtor_obj dtor_obj;
+ struct dtor_obj {
+   dtor_fn dtor;
+@@ -29,7 +48,6 @@ struct dtor_obj {
+   dtor_obj *next;
+ };
+ 
+-HANDLE __dso_handle;
+ extern char __mingw_module_is_dll;
+ 
+ static CRITICAL_SECTION lock;
+@@ -170,3 +188,5 @@ static void WINAPI tls_callback(HANDLE hDllHandle, DWORD dwReason, LPVOID __UNUS
+ }
+ 
+ _CRTALLOC(".CRT$XLB") PIMAGE_TLS_CALLBACK __xl_b = (PIMAGE_TLS_CALLBACK) tls_callback;
++
++#endif  /* __USING_MCFGTHREAD__  */
+diff --git a/mingw-w64-crt/crt/ucrt_exit_wrappers.c b/mingw-w64-crt/crt/ucrt_exit_wrappers.c
+index 112d8e3c7..4ef52a687 100644
+--- a/mingw-w64-crt/crt/ucrt_exit_wrappers.c
++++ b/mingw-w64-crt/crt/ucrt_exit_wrappers.c
+@@ -14,7 +14,11 @@ extern void (*__MINGW_IMP_SYMBOL(quick_exit))(int) __attribute__((__noreturn__))
+ 
+ void quick_exit(int status)
+ {
++#ifdef __USING_MCFGTHREAD__
++  __MCF_quick_exit(status);
++#else
+   (*__MINGW_IMP_SYMBOL(quick_exit))(status);
++#endif
+ }
+ 
+ /* `_Exit()`, C99  */
+@@ -23,5 +27,9 @@ extern void (*__MINGW_IMP_SYMBOL(_Exit))(int) __attribute__((__noreturn__));
+ 
+ void _Exit(int status)
+ {
++#ifdef __USING_MCFGTHREAD__
++  __MCF__Exit(status);
++#else
+   (*__MINGW_IMP_SYMBOL(_Exit))(status);
++#endif
+ }
+diff --git a/mingw-w64-crt/crt/ucrtbase_compat.c b/mingw-w64-crt/crt/ucrtbase_compat.c
+index 9eb33e534..893388b90 100644
+--- a/mingw-w64-crt/crt/ucrtbase_compat.c
++++ b/mingw-w64-crt/crt/ucrtbase_compat.c
+@@ -55,8 +55,6 @@ _CRTIMP int __cdecl _configure_wide_argv(int mode);
+ // Declared in new.h, but only visible to C++
+ _CRTIMP int __cdecl _set_new_mode(int _NewMode);
+ 
+-extern char __mingw_module_is_dll;
+-
+ 
+ // Wrappers with legacy msvcrt.dll style API, based on the new ucrtbase.dll functions.
+ int __cdecl __getmainargs(int * _Argc, char *** _Argv, char ***_Env, int _DoWildCard, _startupinfo *_StartInfo)
+@@ -90,6 +88,10 @@ _onexit_t __cdecl _onexit(_onexit_t func)
+ 
+ _onexit_t __cdecl (*__MINGW_IMP_SYMBOL(_onexit))(_onexit_t func) = _onexit;
+ 
++// When using mcfgthread, `at_quick_exit()` is provided in 'exit_wrappers.c'.
++#ifndef __USING_MCFGTHREAD__
++extern char __mingw_module_is_dll;
++
+ int __cdecl at_quick_exit(void (__cdecl *func)(void))
+ {
+   // In a DLL, we can't register a function with _crt_at_quick_exit, because
+@@ -101,6 +103,7 @@ int __cdecl at_quick_exit(void (__cdecl *func)(void))
+ }
+ 
+ int __cdecl (*__MINGW_IMP_SYMBOL(at_quick_exit))(void (__cdecl *)(void)) = at_quick_exit;
++#endif  // __USING_MCFGTHREAD__
+ 
+ extern void (*__MINGW_IMP_SYMBOL(_exit))(int) __attribute__((__noreturn__));
+ 
+-- 
+2.41.0
+

--- a/scripts/licenses.sh
+++ b/scripts/licenses.sh
@@ -70,6 +70,7 @@ function func_get_licenses {
 		cloog
 		libiconv
 		zlib
+		$( [[ $THREADS_MODEL == mcf ]] && echo mcfgthread )
 		mingw-w64
 		winpthreads
 		binutils

--- a/scripts/mcfgthread.sh
+++ b/scripts/mcfgthread.sh
@@ -3,11 +3,11 @@
 # The BSD 3-Clause License. http://www.opensource.org/licenses/BSD-3-Clause
 #
 # This file is part of MinGW-W64(mingw-builds: https://github.com/niXman/mingw-builds) project.
-# Copyright (c) 2011-2023 by niXman (i dotty nixman doggy gmail dotty com)
+# Copyright (c) 2011-2021 by niXman (i dotty nixman doggy gmail dotty com)
 # Copyright (c) 2012-2015 by Alexpux (alexpux doggy gmail dotty com)
 # All rights reserved.
 #
-# Project: MinGW-Builds ( https://github.com/niXman/mingw-builds )
+# Project: MinGW-W64 ( http://sourceforge.net/projects/mingw-w64/ )
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -35,47 +35,60 @@
 
 # **************************************************************************
 
-PKG_NAME=3rdparty-post
-PKG_DIR_NAME=3rdparty-post
-PKG_PRIORITY=extra
-
-PKG_EXECUTE_AFTER_INSTALL=(
-	python_deps_post
+PKG_VERSION=1.6-ga.1
+PKG_NAME=$PKG_ARCHITECTURE-mcfgthread-${PKG_VERSION}
+PKG_DIR_NAME=mcfgthread-${PKG_VERSION}
+PKG_TYPE=.tar.gz
+PKG_URLS=(
+	"https://github.com/lhmouse/mcfgthread/archive/refs/tags/v${PKG_VERSION}${PKG_TYPE}"
 )
 
-function python_deps_post {
-	case $BUILD_MODE in
-		gcc)
-			local _toolchain_path=$PREFIX
-		;;
-		*)
-			local _toolchain_path=$(eval "echo \${${BUILD_ARCHITECTURE}_HOST_MINGW_PATH}")
-		;;
-	esac
-	local _gcc_dll=( \
-		$(find $_toolchain_path/bin -type f \
-						-name libgcc*.dll -o \
-						-name libmcfgthread*.dll -o \
-						-name libwinpthread*.dll \
-		) \
-	)
-	[[ ${#_gcc_dll[@]} >0 ]] && {
-		cp -f ${_gcc_dll[@]} $LIBS_DIR/bin/ >/dev/null 2>&1
-	}
+PKG_PRIORITY=prereq
 
-	rm -f $LIBS_DIR/bin/{bz*,bunzip2}
-	rm -f $LIBS_DIR/bin/{tclsh.exe,tclsh86.exe,openssl.exe,capinfo.exe,captoinfo.exe,clear.exe,idle,infocmp.exe}
-	rm -f $LIBS_DIR/bin/{infotocap.exe,c_rehash,ncursesw5-config,reset.exe,sqlite3.exe,tabs.exe}
-	rm -f $LIBS_DIR/bin/{tic.exe,toe.exe,tput.exe,tset.exe,wish.exe,wish86.exe,xmlwf,testgdbm.exe}
-	rm -f $LIBS_DIR/bin/{lzmadec.exe,lzmainfo.exe,unxz.exe,xz*}
+#
 
-	#rm -rf $LIBS_DIR/include
-	rm -rf $LIBS_DIR/lib/pkgconfig
-	#find $LIBS_DIR/lib -maxdepth 1 -type f -name *.a -print0 | xargs -0 rm -f
-	find $LIBS_DIR/lib -type f -name *.la -print0 | xargs -0 rm -f
-	rm -rf $LIBS_DIR/man
-	rm -rf $LIBS_DIR/share/man
-	rm -rf $LIBS_DIR/share/info
-}
+PKG_PATCHES=()
+
+#
+
+PKG_EXECUTE_AFTER_PATCH=(
+	"autoreconf -i"
+)
+
+#
+
+PKG_CONFIGURE_FLAGS=(
+	--host=$HOST
+	--build=$BUILD
+	--target=$TARGET
+	#
+	--prefix=$PREREQ_DIR/$PKG_ARCHITECTURE-mcfgthread
+	#
+	CFLAGS="\"$COMMON_CFLAGS\""
+	CXXFLAGS="\"$COMMON_CXXFLAGS\""
+	CPPFLAGS="\"$COMMON_CPPFLAGS\""
+	LDFLAGS="\"$COMMON_LDFLAGS\""
+)
+
+#
+
+PKG_MAKE_FLAGS=(
+	-j$JOBS
+	all
+)
+
+#
+
+PKG_TESTSUITE_FLAGS=(
+	-j$JOBS
+	check
+)
+
+#
+
+PKG_INSTALL_FLAGS=(
+	-j$JOBS
+	$( [[ $STRIP_ON_INSTALL == yes ]] && echo install-strip || echo install )
+)
 
 # **************************************************************************

--- a/scripts/mingw-w64-crt.sh
+++ b/scripts/mingw-w64-crt.sh
@@ -55,6 +55,21 @@ PKG_PATCHES=(
 		    echo "mingw-w64/bceadc54d8f32b3f14c69074892e2718eac08e3b.patch"
 		}
 	)
+	$( [[ $RUNTIME_MAJOR_VERSION -ge 11 ]] && {
+		echo "mingw-w64/9001-crt-Mark-atexit-as-DATA-because-it-s-always-overridd.patch"
+		[[ $RUNTIME_MAJOR_VERSION -ge 12 ]] && {
+			echo "mingw-w64/9002-crt-Provide-wrappers-for-exit-in-libmingwex.patch"
+		} || {
+			echo "mingw-w64/9002-v11-crt-Provide-wrappers-for-exit-in-libmingwex.patch"
+		}
+		echo "mingw-w64/9003-crt-Implement-standard-conforming-termination-suppor.patch"
+	})
+)
+
+#
+
+PKG_EXECUTE_AFTER_PATCH=(
+	"automake"
 )
 
 #
@@ -71,6 +86,14 @@ PKG_PATCHES=(
 	}
 }
 
+[[ -d $PREREQ_DIR ]] && {
+	pushd $PREREQ_DIR > /dev/null
+	PREREQW_DIR=`pwd -W`
+	popd > /dev/null
+}
+
+MY_CPPFLAGS=$( [[ $THREADS_MODEL == mcf ]] && echo "-D__USING_MCFGTHREAD__ -I$PREREQW_DIR/$BUILD_ARCHITECTURE-mcfgthread/include" )
+
 PKG_CONFIGURE_FLAGS=(
 	--host=$HOST
 	--build=$BUILD
@@ -85,7 +108,7 @@ PKG_CONFIGURE_FLAGS=(
 	#
 	CFLAGS="\"$COMMON_CFLAGS\""
 	CXXFLAGS="\"$COMMON_CXXFLAGS\""
-	CPPFLAGS="\"$COMMON_CPPFLAGS\""
+	CPPFLAGS="\"$COMMON_CPPFLAGS $MY_CPPFLAGS\""
 	LDFLAGS="\"$COMMON_LDFLAGS\""
 )
 

--- a/scripts/mingw-w64-runtime-post.sh
+++ b/scripts/mingw-w64-runtime-post.sh
@@ -93,6 +93,16 @@ function runtime_post_install {
 	cp -fv $RUNTIME_DIR/$BUILD_ARCHITECTURE-winpthreads-$RUNTIME_VERSION/lib/libpthread.a $PREFIX/$TARGET/lib/ || { echo "18"; return 1; }
 	cp -fv $RUNTIME_DIR/$BUILD_ARCHITECTURE-winpthreads-$RUNTIME_VERSION/include/*.h $PREFIX/$TARGET/include/ || { echo "19"; return 1; }
 
+	[[ $THREADS_MODEL == mcf ]] && {
+		# mcfgthread
+		mkdir -pv $PREFIX/$TARGET/include/mcfgthread
+		cp -fv $PREREQ_DIR/$BUILD_ARCHITECTURE-mcfgthread/bin/libmcfgthread-1.dll $PREFIX/bin/ || { echo "101"; return 1; }
+		cp -fv $PREREQ_DIR/$BUILD_ARCHITECTURE-mcfgthread/bin/libmcfgthread-1.dll $PREFIX/$TARGET/lib/ || { echo "102"; return 1; }
+		cp -fv $PREREQ_DIR/$BUILD_ARCHITECTURE-mcfgthread/lib/libmcfgthread.dll.a $PREFIX/$TARGET/lib/ || { echo "103"; return 1; }
+		cp -fv $PREREQ_DIR/$BUILD_ARCHITECTURE-mcfgthread/lib/libmcfgthread.a $PREFIX/$TARGET/lib/ || { echo "104"; return 1; }
+		cp -fv $PREREQ_DIR/$BUILD_ARCHITECTURE-mcfgthread/include/mcfgthread/*.h $PREFIX/$TARGET/include/mcfgthread/ || { echo "105"; return 1; }
+		cp -fv $PREREQ_DIR/$BUILD_ARCHITECTURE-mcfgthread/include/mcfgthread/*.hpp $PREFIX/$TARGET/include/mcfgthread/ || { echo "106"; return 1; }
+	}
 
 	[[ $USE_MULTILIB == yes ]] && {
 		local _reverse_bits=$(func_get_reverse_arch_bit $BUILD_ARCHITECTURE)
@@ -124,6 +134,13 @@ function runtime_post_install {
 		cp -fv $RUNTIME_DIR/$_reverse_arch-winpthreads-$RUNTIME_VERSION/lib/libpthread.dll.a $PREFIX/$TARGET/lib$_reverse_bits/ || { echo "28"; return 1; }
 		cp -fv $RUNTIME_DIR/$_reverse_arch-winpthreads-$RUNTIME_VERSION/lib/libwinpthread.a $PREFIX/$TARGET/lib$_reverse_bits/ || { echo "29"; return 1; }
 		cp -fv $RUNTIME_DIR/$_reverse_arch-winpthreads-$RUNTIME_VERSION/lib/libpthread.a $PREFIX/$TARGET/lib$_reverse_bits/ || { echo "30"; return 1; }
+
+		[[ $THREADS_MODEL == mcf ]] && {
+			# mcfgthread
+			cp -fv $PREREQ_DIR/$_reverse_arch-mcfgthread/bin/libmcfgthread-1.dll $PREFIX/$TARGET/lib$_reverse_bits/ || { echo "107"; return 1; }
+			cp -fv $PREREQ_DIR/$_reverse_arch-mcfgthread/lib/libmcfgthread.dll.a $PREFIX/$TARGET/lib$_reverse_bits/ || { echo "108"; return 1; }
+			cp -fv $PREREQ_DIR/$_reverse_arch-mcfgthread/lib/libmcfgthread.a $PREFIX/$TARGET/lib$_reverse_bits/ || { echo "109"; return 1; }
+		}
 
 		mkdir -pv $BUILDS_DIR/$GCC_NAME/$TARGET/$_reverse_bits/{libgcc,libgfortran,libgomp,libitm,libquadmath,libssp,libstdc++-v3}
 		echo $BUILDS_DIR/$GCC_NAME/$TARGET/$_reverse_bits/{libgcc,libgfortran,libgomp,libitm,libquadmath,libssp,libstdc++-v3} \

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -121,10 +121,10 @@ PKG_TESTS["dll_test2"]=dll_test2_list[@]
 [[ "$DISABLE_GCC_LTO" != yes ]] && { PKG_TESTS["lto_test"]=lto_test_list[@]; }
 PKG_TESTS["omp_test"]=omp_test_list[@]
 PKG_TESTS["pthread_test"]=pthread_test_list[@]
-[[ `echo $TESTS_GCC_VERSION | cut -d. -f1` -ge 13 || $THREADS_MODEL == posix ]] && { PKG_TESTS["stdthread_test"]=stdthread_test_list[@]; }
+[[ `echo $TESTS_GCC_VERSION | cut -d. -f1` -ge 13 || $THREADS_MODEL != win32 ]] && { PKG_TESTS["stdthread_test"]=stdthread_test_list[@]; }
 PKG_TESTS["lasterror_test1"]=lasterror_test1_list[@]
 PKG_TESTS["lasterror_test2"]=lasterror_test2_list[@]
 PKG_TESTS["time_test"]=time_test_list[@]
-[[ `echo $TESTS_GCC_VERSION | cut -d. -f1` -ge 13 || $THREADS_MODEL == posix ]] && { PKG_TESTS["sleep_test"]=sleep_test_list[@]; }
+[[ `echo $TESTS_GCC_VERSION | cut -d. -f1` -ge 13 || $THREADS_MODEL != win32 ]] && { PKG_TESTS["sleep_test"]=sleep_test_list[@]; }
 [[ `echo $TESTS_GCC_VERSION | cut -d. -f1` -ge 6 ]] && { PKG_TESTS["random_device"]=random_device_list[@]; }
 [[ `echo $TESTS_GCC_VERSION | cut -d. -f1` -ge 8 ]] && { PKG_TESTS["filesystem"]=filesystem_list[@]; }


### PR DESCRIPTION
WIP. I think it's easier for us to discuss the issues when we have actual code.

- [x] ~~I couldn't build `9004-crt-Copy-clock-and-nanosleep-from-winpthreads.patch` so I commented it out.~~ This patch seems unnecessary.
- [x] ~~The CRT patches only apply to `trunk` and not v11.~~ Fixed.
- [x] ~~How do we bootstrap the first toolchain?~~ Apparently we don't have to.
- [ ] Update README.

Closes #658.
