### PR TITLE
Avoid infinite recursion in libgcc for mcf thread model + sjlj exception handling

### DIFF
--- a/patches/gcc/gcc-13-mcf-sjlj-avoid-infinite-recursion.patch
+++ b/patches/gcc/gcc-13-mcf-sjlj-avoid-infinite-recursion.patch
@@ -1,0 +1,22 @@
+--- a/libgcc/unwind-sjlj.c
++++ b/libgcc/unwind-sjlj.c
+@@ -111,8 +111,19 @@
+ fc_key_init_once (void)
+ {
+   static __gthread_once_t once = __GTHREAD_ONCE_INIT;
++#ifdef __USING_MCFGTHREAD__
++  if (_MCF_once_wait (&once, NULL) == 1)
++    {
++      fc_key_init ();
++      _MCF_once_release (&once);
++    }
++
++  if (use_fc_key < 0)
++    use_fc_key = 0;
++#else
+   if (__gthread_once (&once, fc_key_init) != 0 || use_fc_key < 0)
+     use_fc_key = 0;
++#endif
+ }
+ #endif
+ 

--- a/scripts/gcc-13-branch.sh
+++ b/scripts/gcc-13-branch.sh
@@ -58,6 +58,7 @@ PKG_PATCHES=(
 	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
 	gcc/gcc-10-libgcc-ldflags.patch
 	gcc/gcc-12-replace-abort-with-fancy_abort.patch
+	gcc/gcc-13-mcf-sjlj-avoid-infinite-recursion.patch
 )
 
 #

--- a/scripts/gcc-13.1.0.sh
+++ b/scripts/gcc-13.1.0.sh
@@ -57,7 +57,8 @@ PKG_PATCHES=(
 	gcc/gcc-libgomp-ftime64.patch
 	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
 	gcc/gcc-10-libgcc-ldflags.patch
-    gcc/gcc-12-replace-abort-with-fancy_abort.patch
+	gcc/gcc-12-replace-abort-with-fancy_abort.patch
+	gcc/gcc-13-mcf-sjlj-avoid-infinite-recursion.patch
 )
 
 #

--- a/scripts/gcc-13.2.0.sh
+++ b/scripts/gcc-13.2.0.sh
@@ -58,6 +58,7 @@ PKG_PATCHES=(
 	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
 	gcc/gcc-10-libgcc-ldflags.patch
 	gcc/gcc-12-replace-abort-with-fancy_abort.patch
+	gcc/gcc-13-mcf-sjlj-avoid-infinite-recursion.patch
 )
 
 #

--- a/scripts/gcc-trunk.sh
+++ b/scripts/gcc-trunk.sh
@@ -58,6 +58,7 @@ PKG_PATCHES=(
 	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
 	gcc/gcc-10-libgcc-ldflags.patch
 	gcc/gcc-12-replace-abort-with-fancy_abort.patch
+	gcc/gcc-13-mcf-sjlj-avoid-infinite-recursion.patch
 )
 
 #


### PR DESCRIPTION
This change will fix mcf thread model combined with sjlj exception handling.

See also lhmouse/mcfgthread#91.
