### PR TITLE
Enable wildcard expansion in gcc

### DIFF
--- a/scripts/gcc-10-branch.sh
+++ b/scripts/gcc-10-branch.sh
@@ -103,6 +103,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-10.1.0.sh
+++ b/scripts/gcc-10.1.0.sh
@@ -96,6 +96,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-10.2.0.sh
+++ b/scripts/gcc-10.2.0.sh
@@ -97,6 +97,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-10.3.0.sh
+++ b/scripts/gcc-10.3.0.sh
@@ -97,6 +97,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-10.4.0.sh
+++ b/scripts/gcc-10.4.0.sh
@@ -102,6 +102,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-10.5.0.sh
+++ b/scripts/gcc-10.5.0.sh
@@ -103,6 +103,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-11-branch.sh
+++ b/scripts/gcc-11-branch.sh
@@ -99,6 +99,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-11.1.0.sh
+++ b/scripts/gcc-11.1.0.sh
@@ -97,6 +97,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-11.2.0.sh
+++ b/scripts/gcc-11.2.0.sh
@@ -98,6 +98,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-11.3.0.sh
+++ b/scripts/gcc-11.3.0.sh
@@ -92,6 +92,7 @@ PKG_CONFIGURE_FLAGS=(
 	--enable-lto
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-11.4.0.sh
+++ b/scripts/gcc-11.4.0.sh
@@ -93,6 +93,7 @@ PKG_CONFIGURE_FLAGS=(
 	--enable-lto
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-11.5.0.sh
+++ b/scripts/gcc-11.5.0.sh
@@ -93,6 +93,7 @@ PKG_CONFIGURE_FLAGS=(
 	--enable-lto
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-12-branch.sh
+++ b/scripts/gcc-12-branch.sh
@@ -99,6 +99,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-12.1.0.sh
+++ b/scripts/gcc-12.1.0.sh
@@ -92,6 +92,7 @@ PKG_CONFIGURE_FLAGS=(
 	--enable-lto
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-12.2.0.sh
+++ b/scripts/gcc-12.2.0.sh
@@ -98,6 +98,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-12.3.0.sh
+++ b/scripts/gcc-12.3.0.sh
@@ -99,6 +99,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-12.4.0.sh
+++ b/scripts/gcc-12.4.0.sh
@@ -99,6 +99,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-13-branch.sh
+++ b/scripts/gcc-13-branch.sh
@@ -98,6 +98,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-13.1.0.sh
+++ b/scripts/gcc-13.1.0.sh
@@ -98,6 +98,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-13.2.0.sh
+++ b/scripts/gcc-13.2.0.sh
@@ -98,6 +98,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-13.3.0.sh
+++ b/scripts/gcc-13.3.0.sh
@@ -98,6 +98,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-14-branch.sh
+++ b/scripts/gcc-14-branch.sh
@@ -101,6 +101,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-14.1.0.sh
+++ b/scripts/gcc-14.1.0.sh
@@ -101,6 +101,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-14.2.0.sh
+++ b/scripts/gcc-14.2.0.sh
@@ -101,6 +101,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-8-branch.sh
+++ b/scripts/gcc-8-branch.sh
@@ -94,6 +94,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-8.1.0.sh
+++ b/scripts/gcc-8.1.0.sh
@@ -95,6 +95,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-8.2.0.sh
+++ b/scripts/gcc-8.2.0.sh
@@ -95,6 +95,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-8.3.0.sh
+++ b/scripts/gcc-8.3.0.sh
@@ -95,6 +95,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-8.4.0.sh
+++ b/scripts/gcc-8.4.0.sh
@@ -94,6 +94,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-8.5.0.sh
+++ b/scripts/gcc-8.5.0.sh
@@ -100,6 +100,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-9-branch.sh
+++ b/scripts/gcc-9-branch.sh
@@ -96,6 +96,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-9.1.0.sh
+++ b/scripts/gcc-9.1.0.sh
@@ -96,6 +96,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-9.2.0.sh
+++ b/scripts/gcc-9.2.0.sh
@@ -96,6 +96,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-9.3.0.sh
+++ b/scripts/gcc-9.3.0.sh
@@ -96,6 +96,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-9.4.0.sh
+++ b/scripts/gcc-9.4.0.sh
@@ -97,6 +97,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-9.5.0.sh
+++ b/scripts/gcc-9.5.0.sh
@@ -101,6 +101,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes

--- a/scripts/gcc-trunk.sh
+++ b/scripts/gcc-trunk.sh
@@ -98,6 +98,7 @@ PKG_CONFIGURE_FLAGS=(
 	)
 	--enable-graphite
 	--enable-checking=release
+	--enable-mingw-wildcard
 	--enable-fully-dynamic-string
 	--enable-version-specific-runtime-libs
 	--enable-libstdcxx-filesystem-ts=yes


### PR DESCRIPTION
#698 disabled wildcard expansion by default, but it broke commands like `gcc *.c` to compile everything in one shot.

This PR restores wildcard expansion for gcc only. See also https://github.com/niXman/mingw-builds/pull/698#issuecomment-2760230828.
