### PR TITLE
Add GCC 16.1

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -12,53 +12,53 @@ jobs:
         config:
         - {
             name: "x86_64 posix seh msvcrt",
-            artifact: "x86_64-15.2.0-release-posix-seh-msvcrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-15.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --logviewer-command=cat"
+            artifact: "x86_64-16.1.0-release-posix-seh-msvcrt-rt_v14-rev0.7z",
+            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --logviewer-command=cat"
           }
         - {
             name: "x86_64 posix seh ucrt",
-            artifact: "x86_64-15.2.0-release-posix-seh-ucrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-15.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
+            artifact: "x86_64-16.1.0-release-posix-seh-ucrt-rt_v14-rev0.7z",
+            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
           }
         - {
             name: "x86_64 win32 seh msvcrt",
-            artifact: "x86_64-15.2.0-release-win32-seh-msvcrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-15.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --logviewer-command=cat"
+            artifact: "x86_64-16.1.0-release-win32-seh-msvcrt-rt_v14-rev0.7z",
+            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --logviewer-command=cat"
           }
         - {
             name: "x86_64 win32 seh ucrt",
-            artifact: "x86_64-15.2.0-release-win32-seh-ucrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-15.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
+            artifact: "x86_64-16.1.0-release-win32-seh-ucrt-rt_v14-rev0.7z",
+            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
           }
         - {
             name: "x86_64 mcf seh ucrt",
-            artifact: "x86_64-15.2.0-release-mcf-seh-ucrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-15.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=mcf --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
+            artifact: "x86_64-16.1.0-release-mcf-seh-ucrt-rt_v14-rev0.7z",
+            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=mcf --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
           }
         - {
             name: "i686 posix dwarf msvcrt",
-            artifact: "i686-15.2.0-release-posix-dwarf-msvcrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-15.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --logviewer-command=cat"
+            artifact: "i686-16.1.0-release-posix-dwarf-msvcrt-rt_v14-rev0.7z",
+            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --logviewer-command=cat"
           }
         - {
             name: "i686 posix dwarf ucrt",
-            artifact: "i686-15.2.0-release-posix-dwarf-ucrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-15.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
+            artifact: "i686-16.1.0-release-posix-dwarf-ucrt-rt_v14-rev0.7z",
+            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
           }
         - {
             name: "i686 win32 dwarf msvcrt",
-            artifact: "i686-15.2.0-release-win32-dwarf-msvcrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-15.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --logviewer-command=cat"
+            artifact: "i686-16.1.0-release-win32-dwarf-msvcrt-rt_v14-rev0.7z",
+            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --logviewer-command=cat"
           }
         - {
             name: "i686 win32 dwarf ucrt",
-            artifact: "i686-15.2.0-release-win32-dwarf-ucrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-15.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
+            artifact: "i686-16.1.0-release-win32-dwarf-ucrt-rt_v14-rev0.7z",
+            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
           }
         - {
             name: "i686 mcf dwarf ucrt",
-            artifact: "i686-15.2.0-release-mcf-dwarf-ucrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-15.2.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=mcf --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
+            artifact: "i686-16.1.0-release-mcf-dwarf-ucrt-rt_v14-rev0.7z",
+            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=mcf --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
           }
 
     steps:
@@ -114,43 +114,43 @@ jobs:
         config:
         - {
             name: "x86_64 posix seh msvcrt",
-            artifact: "x86_64-15.2.0-release-posix-seh-msvcrt-rt_v14-rev0.7z"
+            artifact: "x86_64-16.1.0-release-posix-seh-msvcrt-rt_v14-rev0.7z"
           }
         - {
             name: "x86_64 posix seh ucrt",
-            artifact: "x86_64-15.2.0-release-posix-seh-ucrt-rt_v14-rev0.7z"
+            artifact: "x86_64-16.1.0-release-posix-seh-ucrt-rt_v14-rev0.7z"
           }
         - {
             name: "x86_64 win32 seh msvcrt",
-            artifact: "x86_64-15.2.0-release-win32-seh-msvcrt-rt_v14-rev0.7z"
+            artifact: "x86_64-16.1.0-release-win32-seh-msvcrt-rt_v14-rev0.7z"
           }
         - {
             name: "x86_64 win32 seh ucrt",
-            artifact: "x86_64-15.2.0-release-win32-seh-ucrt-rt_v14-rev0.7z"
+            artifact: "x86_64-16.1.0-release-win32-seh-ucrt-rt_v14-rev0.7z"
           }
         - {
             name: "x86_64 mcf seh ucrt",
-            artifact: "x86_64-15.2.0-release-mcf-seh-ucrt-rt_v14-rev0.7z"
+            artifact: "x86_64-16.1.0-release-mcf-seh-ucrt-rt_v14-rev0.7z"
           }
         - {
             name: "i686 posix dwarf msvcrt",
-            artifact: "i686-15.2.0-release-posix-dwarf-msvcrt-rt_v14-rev0.7z"
+            artifact: "i686-16.1.0-release-posix-dwarf-msvcrt-rt_v14-rev0.7z"
           }
         - {
             name: "i686 posix dwarf ucrt",
-            artifact: "i686-15.2.0-release-posix-dwarf-ucrt-rt_v14-rev0.7z"
+            artifact: "i686-16.1.0-release-posix-dwarf-ucrt-rt_v14-rev0.7z"
           }
         - {
             name: "i686 win32 dwarf msvcrt",
-            artifact: "i686-15.2.0-release-win32-dwarf-msvcrt-rt_v14-rev0.7z"
+            artifact: "i686-16.1.0-release-win32-dwarf-msvcrt-rt_v14-rev0.7z"
           }
         - {
             name: "i686 win32 dwarf ucrt",
-            artifact: "i686-15.2.0-release-win32-dwarf-ucrt-rt_v14-rev0.7z"
+            artifact: "i686-16.1.0-release-win32-dwarf-ucrt-rt_v14-rev0.7z"
           }
         - {
             name: "i686 mcf dwarf ucrt",
-            artifact: "i686-15.2.0-release-mcf-dwarf-ucrt-rt_v14-rev0.7z"
+            artifact: "i686-16.1.0-release-mcf-dwarf-ucrt-rt_v14-rev0.7z"
           }
 
     needs: release

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ At the moment, successfully building the following versions:
   gcc-14.3.0
   gcc-15.1.0
   gcc-15.2.0
+  gcc-16.1.0
   gcc-4.6-branch (currently 4.6.5 prerelease)
   gcc-4.7-branch (currently 4.7.5 prerelease)
   gcc-4.8-branch (currently 4.8.6 prerelease)
@@ -162,7 +163,8 @@ At the moment, successfully building the following versions:
   gcc-13-branch (currently 13.4.1-prerelease)
   gcc-14-branch (currently 14.3.1-prerelease)
   gcc-15-branch (currently 15.2.1-prerelease)
-  gcc-trunk (currently 16.0.0 snapshot)
+  gcc-16-branch (currently 16.1.1-prerelease)
+  gcc-trunk (currently 17.0.0 snapshot)
 ```
 
 Builds also contains patches for building Python 2.7.9 and 3.4.3 versions for support gdb pretty printers.

--- a/build
+++ b/build
@@ -189,7 +189,9 @@ readonly RUN_ARGS="$@"
 	echo "    gcc-15.1.0 (15.1.0 release)"
 	echo "    gcc-15.2.0 (15.2.0 release)"
 	echo "    gcc-15-branch (currently 15.2.1-prerelease)"
-	echo "    gcc-trunk (currently 16.0.0-snapshot)"
+	echo "    gcc-16.1.0 (16.1.0 release)"
+	echo "    gcc-16-branch (currently 16.1.1-prerelease)"
+	echo "    gcc-trunk (currently 17.0.0-snapshot)"
 
 	exit 0
 }

--- a/library/functions.sh
+++ b/library/functions.sh
@@ -999,7 +999,8 @@ function func_map_gcc_name_to_gcc_version {
 		gcc-13-branch)	echo "13.4.1" ;;
 		gcc-14-branch)	echo "14.3.1" ;;
 		gcc-15-branch)	echo "15.2.1" ;;
-		gcc-trunk)		echo "16.0.0" ;;
+		gcc-16-branch)	echo "16.1.1" ;;
+		gcc-trunk)		echo "17.0.0" ;;
 		*) die "gcc name error: $1. terminate." ;;
 	esac
 }

--- a/scripts/gcc-16-branch.sh
+++ b/scripts/gcc-16-branch.sh
@@ -1,0 +1,163 @@
+
+#
+# The BSD 3-Clause License. http://www.opensource.org/licenses/BSD-3-Clause
+#
+# This file is part of MinGW-W64(mingw-builds: https://github.com/niXman/mingw-builds) project.
+# Copyright (c) 2011-2023 by niXman (i dotty nixman doggy gmail dotty com)
+# Copyright (c) 2012-2015 by Alexpux (alexpux doggy gmail dotty com)
+# All rights reserved.
+#
+# Project: MinGW-Builds ( https://github.com/niXman/mingw-builds )
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# - Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the distribution.
+# - Neither the name of the 'MinGW-W64' nor the names of its contributors may
+#     be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# **************************************************************************
+
+PKG_VERSION=16
+PKG_NAME=gcc-${PKG_VERSION}-branch
+PKG_DIR_NAME=gcc-${PKG_VERSION}-branch
+PKG_TYPE=git
+PKG_URLS=(
+	"https://gcc.gnu.org/git/gcc.git|branch:releases/gcc-$PKG_VERSION|repo:$PKG_TYPE|module:$PKG_DIR_NAME"
+)
+
+PKG_PRIORITY=main
+
+#
+
+PKG_PATCHES=(
+	gcc/gcc-5.1-iconv.patch
+	gcc/gcc-4.8-libstdc++export.patch
+	gcc/gcc-12-fix-for-windows-not-minding-non-existant-parent-dirs.patch
+	gcc/gcc-5.1.0-make-xmmintrin-header-cplusplus-compatible.patch
+	gcc/gcc-5-dwarf-regression.patch
+	gcc/gcc-13.2.0-ktietz-libgomp.patch
+	gcc/gcc-libgomp-ftime64.patch
+	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
+	gcc/gcc-10-libgcc-ldflags.patch
+	gcc/gcc-12-replace-abort-with-fancy_abort.patch
+	gcc/gcc-13-mcf-sjlj-avoid-infinite-recursion.patch
+)
+
+#
+
+PKG_CONFIGURE_FLAGS=(
+	--host=$HOST
+	--build=$BUILD
+	--target=$TARGET
+	#
+	--prefix=$MINGWPREFIX
+	--with-sysroot=$PREFIX
+	#--with-gxx-include-dir=$MINGWPREFIX/$TARGET/include/c++
+	#
+	$LINK_TYPE_GCC
+	#
+	$( [[ $USE_MULTILIB == yes ]] \
+		&& echo "--enable-targets=all --enable-multilib" \
+		|| echo "--disable-multilib" \
+	)
+	$( [[ "$DISABLE_GCC_LTO" == yes ]] \
+		&& echo "--enable-languages=$ENABLE_LANGUAGES" \
+		|| echo "--enable-languages=$ENABLE_LANGUAGES,lto"
+	)
+	--enable-libstdcxx-time=yes
+	--enable-threads=$THREADS_MODEL
+	$( [[ $THREADS_MODEL == win32 ]] \
+		&& echo "--enable-libstdcxx-threads=yes" \
+	)
+	--enable-tls
+	--enable-libgomp
+	--enable-libatomic
+	$( [[ "$MSVCRT_PHOBOS_OK" == yes && "$D_LANG_ENABLED" == yes ]] \
+		&& echo "--enable-libphobos"
+	)
+	$( [[ "$DISABLE_GCC_LTO" == yes ]] \
+		&& echo "--disable-lto" \
+		|| echo "--enable-lto"
+	)
+	--enable-graphite
+	--enable-checking=release
+	--enable-mingw-wildcard
+	--enable-fully-dynamic-string
+	--enable-version-specific-runtime-libs
+	--enable-libstdcxx-filesystem-ts=yes
+	$( [[ $EXCEPTIONS_MODEL == dwarf ]] \
+		&& echo "--disable-sjlj-exceptions --with-dwarf2" \
+	)
+	$( [[ $EXCEPTIONS_MODEL == sjlj ]] \
+		&& echo "--enable-sjlj-exceptions" \
+	)
+	#
+	$( [[ $RUNTIME_MAJOR_VERSION -ge 11 ]] \
+		&& echo "--disable-libssp" \
+	)
+	--disable-libstdcxx-pch
+	--disable-libstdcxx-debug
+	$( [[ $BOOTSTRAPING == yes ]] \
+		&& echo "--enable-bootstrap" \
+		|| echo "--disable-bootstrap" \
+	)
+	--disable-rpath
+	--disable-win32-registry
+	--disable-nls
+	--disable-werror
+	--disable-symvers
+	#
+	--with-gnu-as
+	--with-gnu-ld
+	#
+	$PROCESSOR_OPTIMIZATION
+	$PROCESSOR_TUNE
+	#
+	--with-libiconv
+	--with-system-zlib
+	--with-{gmp,mpfr,mpc,isl}=$PREREQ_DIR/$HOST-$LINK_TYPE_SUFFIX
+	--with-pkgversion="\"$BUILD_ARCHITECTURE-$THREADS_MODEL-$EXCEPTIONS_MODEL${REV_STRING}, $MINGW_W64_PKG_STRING\""
+	--with-bugurl=$BUG_URL
+	#
+	CFLAGS="$COMMON_CFLAGS"
+	CXXFLAGS="$COMMON_CXXFLAGS"
+	CPPFLAGS="$COMMON_CPPFLAGS"
+	LDFLAGS="$COMMON_LDFLAGS $( [[ $BUILD_ARCHITECTURE == i686 ]] && echo -Wl,--large-address-aware )"
+	LD_FOR_TARGET=$PREFIX/bin/ld.exe
+	--with-boot-ldflags="\"$LDFLAGS -Wl,--disable-dynamicbase -static-libstdc++ -static-libgcc\""
+)
+
+#
+
+PKG_MAKE_FLAGS=(
+	-j$JOBS
+	all
+)
+
+#
+
+PKG_INSTALL_FLAGS=(
+	-j1
+	DESTDIR=$BASE_BUILD_DIR
+	$( [[ $STRIP_ON_INSTALL == yes ]] && echo install-strip || echo install )
+)
+
+# **************************************************************************

--- a/scripts/gcc-16.1.0.sh
+++ b/scripts/gcc-16.1.0.sh
@@ -1,0 +1,163 @@
+
+#
+# The BSD 3-Clause License. http://www.opensource.org/licenses/BSD-3-Clause
+#
+# This file is part of MinGW-W64(mingw-builds: https://github.com/niXman/mingw-builds) project.
+# Copyright (c) 2011-2023 by niXman (i dotty nixman doggy gmail dotty com)
+# Copyright (c) 2012-2015 by Alexpux (alexpux doggy gmail dotty com)
+# All rights reserved.
+#
+# Project: MinGW-Builds ( https://github.com/niXman/mingw-builds )
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# - Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the distribution.
+# - Neither the name of the 'MinGW-W64' nor the names of its contributors may
+#     be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# **************************************************************************
+
+PKG_VERSION=16.1.0
+PKG_NAME=gcc-${PKG_VERSION}
+PKG_DIR_NAME=gcc-${PKG_VERSION}
+PKG_TYPE=.tar.xz
+PKG_URLS=(
+	"https://ftpmirror.gnu.org/gnu/gcc/gcc-${PKG_VERSION}/gcc-${PKG_VERSION}${PKG_TYPE}"
+)
+
+PKG_PRIORITY=main
+
+#
+
+PKG_PATCHES=(
+	gcc/gcc-5.1-iconv.patch
+	gcc/gcc-4.8-libstdc++export.patch
+	gcc/gcc-12-fix-for-windows-not-minding-non-existant-parent-dirs.patch
+	gcc/gcc-5.1.0-make-xmmintrin-header-cplusplus-compatible.patch
+	gcc/gcc-5-dwarf-regression.patch
+	gcc/gcc-13.2.0-ktietz-libgomp.patch
+	gcc/gcc-libgomp-ftime64.patch
+	gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
+	gcc/gcc-10-libgcc-ldflags.patch
+	gcc/gcc-12-replace-abort-with-fancy_abort.patch
+	gcc/gcc-13-mcf-sjlj-avoid-infinite-recursion.patch
+)
+
+#
+
+PKG_CONFIGURE_FLAGS=(
+	--host=$HOST
+	--build=$BUILD
+	--target=$TARGET
+	#
+	--prefix=$MINGWPREFIX
+	--with-sysroot=$PREFIX
+	#--with-gxx-include-dir=$MINGWPREFIX/$TARGET/include/c++
+	#
+	$LINK_TYPE_GCC
+	#
+	$( [[ $USE_MULTILIB == yes ]] \
+		&& echo "--enable-targets=all --enable-multilib" \
+		|| echo "--disable-multilib" \
+	)
+	$( [[ "$DISABLE_GCC_LTO" == yes ]] \
+		&& echo "--enable-languages=$ENABLE_LANGUAGES" \
+		|| echo "--enable-languages=$ENABLE_LANGUAGES,lto"
+	)
+	--enable-libstdcxx-time=yes
+	--enable-threads=$THREADS_MODEL
+	$( [[ $THREADS_MODEL == win32 ]] \
+		&& echo "--enable-libstdcxx-threads=yes" \
+	)
+	--enable-tls
+	--enable-libgomp
+	--enable-libatomic
+	$( [[ "$MSVCRT_PHOBOS_OK" == yes && "$D_LANG_ENABLED" == yes ]] \
+		&& echo "--enable-libphobos"
+	)
+	$( [[ "$DISABLE_GCC_LTO" == yes ]] \
+		&& echo "--disable-lto" \
+		|| echo "--enable-lto"
+	)
+	--enable-graphite
+	--enable-checking=release
+	--enable-mingw-wildcard
+	--enable-fully-dynamic-string
+	--enable-version-specific-runtime-libs
+	--enable-libstdcxx-filesystem-ts=yes
+	$( [[ $EXCEPTIONS_MODEL == dwarf ]] \
+		&& echo "--disable-sjlj-exceptions --with-dwarf2" \
+	)
+	$( [[ $EXCEPTIONS_MODEL == sjlj ]] \
+		&& echo "--enable-sjlj-exceptions" \
+	)
+	#
+	$( [[ $RUNTIME_MAJOR_VERSION -ge 11 ]] \
+		&& echo "--disable-libssp" \
+	)
+	--disable-libstdcxx-pch
+	--disable-libstdcxx-debug
+	$( [[ $BOOTSTRAPING == yes ]] \
+		&& echo "--enable-bootstrap" \
+		|| echo "--disable-bootstrap" \
+	)
+	--disable-rpath
+	--disable-win32-registry
+	--disable-nls
+	--disable-werror
+	--disable-symvers
+	#
+	--with-gnu-as
+	--with-gnu-ld
+	#
+	$PROCESSOR_OPTIMIZATION
+	$PROCESSOR_TUNE
+	#
+	--with-libiconv
+	--with-system-zlib
+	--with-{gmp,mpfr,mpc,isl}=$PREREQ_DIR/$HOST-$LINK_TYPE_SUFFIX
+	--with-pkgversion="\"$BUILD_ARCHITECTURE-$THREADS_MODEL-$EXCEPTIONS_MODEL${REV_STRING}, $MINGW_W64_PKG_STRING\""
+	--with-bugurl=$BUG_URL
+	#
+	CFLAGS="$COMMON_CFLAGS"
+	CXXFLAGS="$COMMON_CXXFLAGS"
+	CPPFLAGS="$COMMON_CPPFLAGS"
+	LDFLAGS="$COMMON_LDFLAGS $( [[ $BUILD_ARCHITECTURE == i686 ]] && echo -Wl,--large-address-aware )"
+	LD_FOR_TARGET=$PREFIX/bin/ld.exe
+	--with-boot-ldflags="\"$LDFLAGS -Wl,--disable-dynamicbase -static-libstdc++ -static-libgcc\""
+)
+
+#
+
+PKG_MAKE_FLAGS=(
+	-j$JOBS
+	all
+)
+
+#
+
+PKG_INSTALL_FLAGS=(
+	-j1
+	DESTDIR=$BASE_BUILD_DIR
+	$( [[ $STRIP_ON_INSTALL == yes ]] && echo install-strip || echo install )
+)
+
+# **************************************************************************

--- a/scripts/gcc-trunk.sh
+++ b/scripts/gcc-trunk.sh
@@ -87,6 +87,7 @@ PKG_CONFIGURE_FLAGS=(
 	$( [[ $THREADS_MODEL == win32 ]] \
 		&& echo "--enable-libstdcxx-threads=yes" \
 	)
+	--enable-tls
 	--enable-libgomp
 	--enable-libatomic
 	$( [[ "$MSVCRT_PHOBOS_OK" == yes && "$D_LANG_ENABLED" == yes ]] \


### PR DESCRIPTION
GCC now supports Win32 native TLS (thread-local storage) for improved performance. This is an ABI breaking change.

I opted to enable it unconditionally for GCC >= 16 because a major version upgrade is a good opportunity to break ABI.