### PR TITLE
gcc-16.1.0: add patches to fix AVX under win64 abi

### DIFF
--- a/patches/gcc/fix-under-aligned-indirect-AVX-argument-return-stack-slots-win64.patch
+++ b/patches/gcc/fix-under-aligned-indirect-AVX-argument-return-stack-slots-win64.patch
@@ -1,0 +1,355 @@
+From 77b2eaf09c77bf2dddcb8c35ee8bc9cc99e2f93c Mon Sep 17 00:00:00 2001
+From: oltolm <oleg.tolmatcev@gmail.com>
+Date: Sun, 24 May 2026 12:57:49 +0200
+Subject: x86: fix under-aligned indirect AVX argument/return stack slots on
+ win64 [PR54412]
+
+Fix x86 caller/callee handling for over-aligned indirect arguments/returns
+
+On x86_64-w64-mingw32, TARGET_SEH limits MAX_SUPPORTED_STACK_ALIGNMENT
+to 128 bits, but 256-bit AVX values are still passed and returned indirectly.
+Some caller/callee stack-slot paths still used generic allocators that cap
+requested alignment to MAX_SUPPORTED_STACK_ALIGNMENT, producing slots that are
+under-aligned for later vmovapd/vmovaps accesses.
+
+Fix caller-side paths by using dynamically allocated stack space for:
+
+* over-aligned by-reference argument copies
+* over-aligned hidden return slots
+
+Fix callee-side paths by overallocating the local stack slot, then aligning the
+effective address within that slot when required alignment exceeds
+MAX_SUPPORTED_STACK_ALIGNMENT.
+
+This preserves ABI behavior while ensuring alignment-sensitive AVX accesses are
+correctly aligned in both caller and callee paths.
+
+Use a target hook to control when this over-aligned stack-slot handling is
+required, instead of hardcoding target conditionals in generic code.
+
+gcc/ChangeLog:
+
+	PR target/54412
+	* target.def (overaligned_stack_slot_required): New calls hook.
+	* calls.cc (allocate_call_dynamic_stack_space): New helper.
+	(initialize_argument_information): Use
+	targetm.calls.overaligned_stack_slot_required for over-aligned
+	by-reference argument copies.
+	(expand_call): Use
+	targetm.calls.overaligned_stack_slot_required for over-aligned
+	hidden return slots.
+	* function.cc (assign_stack_local_aligned): New helper.
+	(assign_parm_setup_block): Use
+	targetm.calls.overaligned_stack_slot_required for over-aligned
+	stack parm slots.
+	(assign_parm_setup_reg): Likewise.
+	* config/i386/i386.cc (ix86_overaligned_stack_slot_required): New.
+	(TARGET_OVERALIGNED_STACK_SLOT_REQUIRED): Define for i386.
+	* doc/tm.texi.in: Add hook placement.
+	* doc/tm.texi: Regenerate.
+
+Signed-off-by: oltolm <oleg.tolmatcev@gmail.com>
+Signed-off-by: Jonathan Yong <10walls@gmail.com>
+---
+ gcc/calls.cc            | 72 +++++++++++++++++++++++++++++++++++--------------
+ gcc/config/i386/i386.cc | 11 ++++++++
+ gcc/doc/tm.texi         | 10 +++++++
+ gcc/doc/tm.texi.in      |  2 ++
+ gcc/function.cc         | 57 ++++++++++++++++++++++++++-------------
+ gcc/target.def          | 12 +++++++++
+ 6 files changed, 125 insertions(+), 39 deletions(-)
+
+diff --git a/gcc/calls.cc b/gcc/calls.cc
+index d491a4146115..ee885a60b582 100644
+--- a/gcc/calls.cc
++++ b/gcc/calls.cc
+@@ -159,6 +159,8 @@ static void compute_argument_addresses (struct arg_data *, rtx, int);
+ static rtx rtx_for_function_call (tree, tree);
+ static void load_register_parameters (struct arg_data *, int, rtx *, int,
+ 				      int, bool *);
++static rtx allocate_call_dynamic_stack_space (rtx, unsigned int, HOST_WIDE_INT,
++					      rtx *, poly_int64 *);
+ static int special_function_p (const_tree, int);
+ static bool check_sibcall_argument_overlap_1 (rtx);
+ static bool check_sibcall_argument_overlap (rtx_insn *, struct arg_data *,
+@@ -211,6 +213,28 @@ mark_stack_region_used (poly_uint64 lower_bound, poly_uint64 upper_bound)
+     stack_usage_watermark = MIN (stack_usage_watermark, const_lower);
+ }
+
++/* Allocate temporary call-related stack space with ALIGN alignment.
++	 Save the stack pointer on first use so the caller can restore it after
++	 the call sequence completes.  */
++
++static rtx
++allocate_call_dynamic_stack_space (rtx size, unsigned int align,
++				   HOST_WIDE_INT known_size,
++				   rtx *old_stack_level,
++				   poly_int64 *old_pending_adj)
++{
++  if (*old_stack_level == 0)
++    {
++      emit_stack_save (SAVE_BLOCK, old_stack_level);
++      *old_pending_adj = pending_stack_adjust;
++      pending_stack_adjust = 0;
++    }
++
++  /* We can pass TRUE as the 5th argument because we just saved the stack
++	   pointer and will restore it right after the call.  */
++  return allocate_dynamic_stack_space (size, align, align, known_size, true);
++}
++
+ /* Force FUNEXP into a form suitable for the address of a CALL,
+    and return that as an rtx.  Also load the static chain register
+    if FNDECL is a nested function.
+@@ -1481,30 +1505,23 @@ initialize_argument_information (int num_actuals ATTRIBUTE_UNUSED,
+
+ 	      if (!COMPLETE_TYPE_P (type)
+ 		  || TREE_CODE (TYPE_SIZE_UNIT (type)) != INTEGER_CST
++		  || (targetm.calls.overaligned_stack_slot_required ()
++		      && TYPE_ALIGN (type) > MAX_SUPPORTED_STACK_ALIGNMENT)
+ 		  || (flag_stack_check == GENERIC_STACK_CHECK
+ 		      && compare_tree_int (TYPE_SIZE_UNIT (type),
+ 					   STACK_CHECK_MAX_VAR_SIZE) > 0))
+ 		{
+-		  /* This is a variable-sized object.  Make space on the stack
+-		     for it.  */
++		  /* Variable-sized or over-aligned by-reference arguments cannot
++		     use a regular stack temp when the target can't guarantee the
++		     requested alignment for stack slots.  Allocate temporary
++		     space dynamically and restore the stack right after the call.  */
+ 		  rtx size_rtx = expr_size (args[i].tree_value);
+
+-		  if (*old_stack_level == 0)
+-		    {
+-		      emit_stack_save (SAVE_BLOCK, old_stack_level);
+-		      *old_pending_adj = pending_stack_adjust;
+-		      pending_stack_adjust = 0;
+-		    }
+-
+-		  /* We can pass TRUE as the 4th argument because we just
+-		     saved the stack pointer and will restore it right after
+-		     the call.  */
+-		  copy = allocate_dynamic_stack_space (size_rtx,
+-						       TYPE_ALIGN (type),
+-						       TYPE_ALIGN (type),
+-						       max_int_size_in_bytes
+-						       (type),
+-						       true);
++		  copy = allocate_call_dynamic_stack_space (size_rtx,
++						 TYPE_ALIGN (type),
++						 max_int_size_in_bytes (type),
++						 old_stack_level,
++						 old_pending_adj);
+ 		  copy = gen_rtx_MEM (BLKmode, copy);
+ 		  set_mem_attributes (copy, type, 1);
+ 		}
+@@ -2911,8 +2928,23 @@ expand_call (tree exp, rtx target, int ignore)
+ 	    /* For variable-sized objects, we must be called with a target
+ 	       specified.  If we were to allocate space on the stack here,
+ 	       we would have no way of knowing when to free it.  */
+-	    rtx d = assign_temp (rettype, 1, 1);
+-	    structure_value_addr = XEXP (d, 0);
++	    if (targetm.calls.overaligned_stack_slot_required ()
++		&& TYPE_ALIGN (rettype) > MAX_SUPPORTED_STACK_ALIGNMENT)
++	      {
++		unsigned HOST_WIDE_INT size;
++
++		gcc_checking_assert (TREE_CODE (TYPE_SIZE_UNIT (rettype))
++				     == INTEGER_CST);
++		size = tree_to_uhwi (TYPE_SIZE_UNIT (rettype));
++		structure_value_addr = allocate_call_dynamic_stack_space (
++		  gen_int_mode (size, Pmode), TYPE_ALIGN (rettype), size,
++		  &old_stack_level, &old_pending_adj);
++	      }
++	    else
++	      {
++		rtx d = assign_temp (rettype, 1, 1);
++		structure_value_addr = XEXP (d, 0);
++	      }
+ 	    target = 0;
+ 	  }
+       }
+diff --git a/gcc/config/i386/i386.cc b/gcc/config/i386/i386.cc
+index a5559fe8a330..dd1f715b460b 100644
+--- a/gcc/config/i386/i386.cc
++++ b/gcc/config/i386/i386.cc
+@@ -430,6 +430,7 @@ static rtx ix86_function_value (const_tree, const_tree, bool);
+ static bool ix86_function_value_regno_p (const unsigned int);
+ static unsigned int ix86_function_arg_boundary (machine_mode,
+ 						const_tree);
++static bool ix86_overaligned_stack_slot_required (void);
+ static rtx ix86_static_chain (const_tree, bool);
+ static int ix86_function_regparm (const_tree, const_tree);
+ static void ix86_compute_frame_layout (void);
+@@ -1631,6 +1632,14 @@ ix86_must_pass_in_stack (const function_arg_info &arg)
+ 	  && arg.type && TREE_CODE (arg.type) != VECTOR_TYPE);
+ }
+
++/* Implement TARGET_OVERALIGNED_STACK_SLOT_REQUIRED.  */
++
++static bool
++ix86_overaligned_stack_slot_required (void)
++{
++  return TARGET_SEH;
++}
++
+ /* It returns the size, in bytes, of the area reserved for arguments passed
+    in registers for the function represented by fndecl dependent to the used
+    abi format.  */
+@@ -28505,6 +28514,8 @@ static const scoped_attribute_specs *const ix86_attribute_table[] =
+ #define TARGET_SETUP_INCOMING_VARARGS ix86_setup_incoming_varargs
+ #undef TARGET_MUST_PASS_IN_STACK
+ #define TARGET_MUST_PASS_IN_STACK ix86_must_pass_in_stack
++#undef TARGET_OVERALIGNED_STACK_SLOT_REQUIRED
++#define TARGET_OVERALIGNED_STACK_SLOT_REQUIRED ix86_overaligned_stack_slot_required
+ #undef TARGET_ALLOCATE_STACK_SLOTS_FOR_ARGS
+ #define TARGET_ALLOCATE_STACK_SLOTS_FOR_ARGS ix86_allocate_stack_slots_for_args
+ #undef TARGET_FUNCTION_ARG_ADVANCE
+diff --git a/gcc/doc/tm.texi b/gcc/doc/tm.texi
+index a4ae17decb07..04537aa32006 100644
+--- a/gcc/doc/tm.texi
++++ b/gcc/doc/tm.texi
+@@ -4300,6 +4300,16 @@ definition that is usually appropriate, refer to @file{expr.h} for additional
+ documentation.
+ @end deftypefn
+
++@deftypefn {Target Hook} bool TARGET_OVERALIGNED_STACK_SLOT_REQUIRED (void)
++This hook should return @code{true} when call-related stack slots whose
++requested alignment exceeds @code{MAX_SUPPORTED_STACK_ALIGNMENT} need special
++handling on the target.  This covers stack slots created by call expansion
++(such as by-reference argument copies and hidden structure return storage) and
++incoming argument setup.  When @code{true}, GCC may avoid normal fixed stack
++slots for such cases and use over-allocation plus dynamic address alignment
++instead.
++@end deftypefn
++
+ @deftypefn {Target Hook} rtx TARGET_FUNCTION_INCOMING_ARG (cumulative_args_t @var{ca}, const function_arg_info @var{&arg})
+ Define this hook if the caller and callee on the target have different
+ views of where arguments are passed.  Also define this hook if there are
+diff --git a/gcc/doc/tm.texi.in b/gcc/doc/tm.texi.in
+index 1acda0c264cc..e31d7440b75a 100644
+--- a/gcc/doc/tm.texi.in
++++ b/gcc/doc/tm.texi.in
+@@ -3358,6 +3358,8 @@ the stack.
+
+ @hook TARGET_MUST_PASS_IN_STACK
+
++@hook TARGET_OVERALIGNED_STACK_SLOT_REQUIRED
++
+ @hook TARGET_FUNCTION_INCOMING_ARG
+
+ @hook TARGET_USE_PSEUDO_PIC_REG
+diff --git a/gcc/function.cc b/gcc/function.cc
+index 109821c16fc9..84023070ad8b 100644
+--- a/gcc/function.cc
++++ b/gcc/function.cc
+@@ -155,6 +155,8 @@ static bool contains (const rtx_insn *, hash_table<insn_cache_hasher> *);
+ static void prepare_function_start (void);
+ static void do_clobber_return_reg (rtx, void *);
+ static void do_use_return_reg (rtx, void *);
++static rtx assign_stack_local_aligned (machine_mode, poly_int64,
++              unsigned int);
+
+ 
+ /* Stack of nested functions.  */
+@@ -551,6 +553,36 @@ assign_stack_local (machine_mode mode, poly_int64 size, int align)
+   return assign_stack_local_1 (mode, size, align, ASLK_RECORD_PAD);
+ }
+ 
++/* Like assign_stack_local, but preserve requested over-alignment by
++   overallocating a BLKmode slot and aligning an address within it.  */
++
++static rtx
++assign_stack_local_aligned (machine_mode mode, poly_int64 size,
++			    unsigned int align)
++{
++  if (targetm.calls.overaligned_stack_slot_required ()
++      && align > MAX_SUPPORTED_STACK_ALIGNMENT)
++    {
++      if (!size.is_constant ())
++	return assign_stack_local (mode, size, MAX_SUPPORTED_STACK_ALIGNMENT);
++
++      rtx allocsize = gen_int_mode (size, Pmode);
++      get_dynamic_stack_size (&allocsize, 0, align, NULL);
++
++      if (!CONST_INT_P (allocsize))
++	return assign_stack_local (mode, size, MAX_SUPPORTED_STACK_ALIGNMENT);
++
++      rtx slot = assign_stack_local (BLKmode, UINTVAL (allocsize),
++				     MAX_SUPPORTED_STACK_ALIGNMENT);
++      rtx addr = align_dynamic_address (XEXP (slot, 0), align);
++      mark_reg_pointer (addr, align);
++      slot = gen_rtx_MEM (mode, addr);
++      MEM_NOTRAP_P (slot) = 1;
++      return slot;
++    }
++  return assign_stack_local (mode, size, align);
++}
++
+ /* In order to evaluate some expressions, such as function calls returning
+    structures in memory, we need to temporarily allocate stack locations.
+    We record each allocated temporary in the following structure.
+@@ -2948,21 +2980,8 @@ assign_parm_setup_block (struct assign_parm_data_all *all,
+ 	   ? MAX (DECL_ALIGN (parm), BITS_PER_WORD) : DECL_ALIGN (parm));
+
+       SET_DECL_ALIGN (parm, parm_align);
+-      if (DECL_ALIGN (parm) > MAX_SUPPORTED_STACK_ALIGNMENT)
+-	{
+-	  rtx allocsize = gen_int_mode (size_stored, Pmode);
+-	  get_dynamic_stack_size (&allocsize, 0, DECL_ALIGN (parm), NULL);
+-	  stack_parm = assign_stack_local (BLKmode, UINTVAL (allocsize),
+-					   MAX_SUPPORTED_STACK_ALIGNMENT);
+-	  rtx addr = align_dynamic_address (XEXP (stack_parm, 0),
+-					    DECL_ALIGN (parm));
+-	  mark_reg_pointer (addr, DECL_ALIGN (parm));
+-	  stack_parm = gen_rtx_MEM (GET_MODE (stack_parm), addr);
+-	  MEM_NOTRAP_P (stack_parm) = 1;
+-	}
+-      else
+-	stack_parm = assign_stack_local (BLKmode, size_stored,
+-					 DECL_ALIGN (parm));
++      stack_parm
++	= assign_stack_local_aligned (BLKmode, size_stored, DECL_ALIGN (parm));
+       if (known_eq (GET_MODE_SIZE (GET_MODE (entry_parm)), size))
+ 	PUT_MODE (stack_parm, GET_MODE (entry_parm));
+       set_mem_attributes (stack_parm, parm, 1);
+@@ -3366,10 +3385,10 @@ assign_parm_setup_reg (struct assign_parm_data_all *all, tree parm,
+ 	  int align = STACK_SLOT_ALIGNMENT (TREE_TYPE (parm),
+ 					    TYPE_MODE (TREE_TYPE (parm)),
+ 					    TYPE_ALIGN (TREE_TYPE (parm)));
+-	  parmreg
+-	    = assign_stack_local (TYPE_MODE (TREE_TYPE (parm)),
+-				  GET_MODE_SIZE (TYPE_MODE (TREE_TYPE (parm))),
+-				  align);
++	  parmreg = assign_stack_local_aligned (TYPE_MODE (TREE_TYPE (parm)),
++						GET_MODE_SIZE (
++						  TYPE_MODE (TREE_TYPE (parm))),
++						align);
+ 	  set_mem_attributes (parmreg, parm, 1);
+ 	}
+
+diff --git a/gcc/target.def b/gcc/target.def
+index cdb3a6a6c840..0b7436b67a4b 100644
+--- a/gcc/target.def
++++ b/gcc/target.def
+@@ -5211,6 +5211,18 @@ documentation.",
+  bool, (const function_arg_info &arg),
+  must_pass_in_stack_var_size_or_pad)
+
++DEFHOOK
++(overaligned_stack_slot_required,
++ "This hook should return @code{true} when call-related stack slots whose\n\
++requested alignment exceeds @code{MAX_SUPPORTED_STACK_ALIGNMENT} need special\n\
++handling on the target.  This covers stack slots created by call expansion\n\
++(such as by-reference argument copies and hidden structure return storage) and\n\
++incoming argument setup.  When @code{true}, GCC may avoid normal fixed stack\n\
++slots for such cases and use over-allocation plus dynamic address alignment\n\
++instead.",
++ bool, (void),
++ hook_bool_void_false)
++
+ /* Return true if type TYPE, mode MODE, which is passed by reference,
+    should have the object copy generated by the callee rather than
+    the caller.  It is never called for TYPE requiring constructors.  */
+--
+cgit

--- a/patches/gcc/return-256-512-bit-vectors-in-registers-x86_64-MS-ABI.patch
+++ b/patches/gcc/return-256-512-bit-vectors-in-registers-x86_64-MS-ABI.patch
@@ -1,0 +1,124 @@
+From ae4efe523b80321fd885412fbc98e2102abc6178 Mon Sep 17 00:00:00 2001
+From: oltolm <oleg.tolmatcev@gmail.com>
+Date: Tue, 19 May 2026 19:34:42 +0200
+Subject: i386: return 256/512-bit vectors in registers for x86_64 MS ABI
+ [PR89597]
+
+On x86_64 Windows targets using MS ABI, GCC classified 256-bit and
+512-bit vector returns as memory returns.  That caused hidden sret
+pointer returns where YMM0/ZMM0 returns are expected.
+
+Teach MS ABI return classification to keep 32-byte and 64-byte vector
+returns in registers when AVX/AVX512F is enabled, matching the return
+register selection path.
+
+Also extend function_value_ms_64 so 32-byte and 64-byte eligible vector
+returns are mapped to the SSE register class (YMM0/ZMM0 lanes).
+
+Add tests for x86_64-*-mingw* that verify 256-bit and 512-bit vector
+returns use YMM0/ZMM0 codegen.
+
+gcc:
+
+	PR target/89597
+	* config/i386/i386.cc (function_value_ms_64): Handle 32-byte and
+	64-byte vector returns in registers when supported.
+	(ix86_return_in_memory): Do not force 32-byte/64-byte eligible
+	vector returns to memory for MS ABI.
+
+gcc/testsuite:
+
+	* gcc.target/i386/pr89597-1.c: New test.
+	* gcc.target/i386/pr89597-2.c: New test.
+
+Signed-off-by: Oleg Tolmatcev <oleg.tolmatcev@gmail.com>
+Signed-off-by: Jonathan Yong <10walls@gmail.com>
+---
+ gcc/config/i386/i386.cc                   | 18 +++++++++++++++---
+ gcc/testsuite/gcc.target/i386/pr89597-1.c | 12 ++++++++++++
+ gcc/testsuite/gcc.target/i386/pr89597-2.c | 12 ++++++++++++
+ 3 files changed, 39 insertions(+), 3 deletions(-)
+ create mode 100644 gcc/testsuite/gcc.target/i386/pr89597-1.c
+ create mode 100644 gcc/testsuite/gcc.target/i386/pr89597-2.c
+
+diff --git a/gcc/config/i386/i386.cc b/gcc/config/i386/i386.cc
+index 2744c7495780..a5559fe8a330 100644
+--- a/gcc/config/i386/i386.cc
++++ b/gcc/config/i386/i386.cc
+@@ -4346,9 +4346,17 @@ function_value_ms_64 (machine_mode orig_mode, machine_mode mode,
+
+   if (TARGET_SSE)
+     {
+-      switch (GET_MODE_SIZE (mode))
++      unsigned int mode_size = GET_MODE_SIZE (mode);
++
++      switch (mode_size)
+ 	{
+ 	case 16:
++	case 32:
++	case 64:
++	  if (mode_size == 32 && !TARGET_AVX)
++	    break;
++	  if (mode_size == 64 && !TARGET_AVX512F)
++	    break;
+ 	  if (valtype != NULL_TREE
+ 	      && !VECTOR_INTEGER_TYPE_P (valtype)
+ 	      && !INTEGRAL_TYPE_P (valtype)
+@@ -4458,13 +4466,17 @@ ix86_return_in_memory (const_tree type, const_tree fntype ATTRIBUTE_UNUSED)
+ 	{
+ 	  size = int_size_in_bytes (type);
+
+-	  /* __m128 is returned in xmm0.  */
++	  /* __m128 is returned in xmm0.  256/512-bit vector values are
++	     returned in ymm0/zmm0 when AVX/AVX512 is enabled.  */
+ 	  if ((!type || VECTOR_INTEGER_TYPE_P (type)
+ 	       || INTEGRAL_TYPE_P (type)
+ 	       || VECTOR_FLOAT_TYPE_P (type))
+ 	      && (SCALAR_INT_MODE_P (mode) || VECTOR_MODE_P (mode))
+ 	      && !COMPLEX_MODE_P (mode)
+-	      && (GET_MODE_SIZE (mode) == 16 || size == 16))
++	      && ((GET_MODE_SIZE (mode) == 16 || size == 16)
++		  || (TARGET_AVX && (GET_MODE_SIZE (mode) == 32 || size == 32))
++		  || (TARGET_AVX512F
++		      && (GET_MODE_SIZE (mode) == 64 || size == 64))))
+ 	    return false;
+
+ 	  /* Otherwise, the size must be exactly in [1248]. */
+diff --git a/gcc/testsuite/gcc.target/i386/pr89597-1.c b/gcc/testsuite/gcc.target/i386/pr89597-1.c
+new file mode 100644
+index 000000000000..5dfd9cd86e20
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/i386/pr89597-1.c
+@@ -0,0 +1,12 @@
++/* { dg-do compile { target x86_64-*-mingw* } } */
++/* { dg-options "-O1 -mavx" } */
++
++typedef long long __m256i __attribute__ ((__vector_size__ (32)));
++
++__m256i
++foo (void)
++{
++  return (__m256i) { 1, 2, 3, 4 };
++}
++
++/* { dg-final { scan-assembler "ymm0" } } */
+diff --git a/gcc/testsuite/gcc.target/i386/pr89597-2.c b/gcc/testsuite/gcc.target/i386/pr89597-2.c
+new file mode 100644
+index 000000000000..25e737a9c65c
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/i386/pr89597-2.c
+@@ -0,0 +1,12 @@
++/* { dg-do compile { target x86_64-*-mingw* } } */
++/* { dg-options "-O1 -mavx512f" } */
++
++typedef long long __m512i __attribute__ ((__vector_size__ (64)));
++
++__m512i
++foo (void)
++{
++  return (__m512i) { 1, 2, 3, 4, 5, 6, 7, 8 };
++}
++
++/* { dg-final { scan-assembler "zmm0" } } */
+--
+cgit

--- a/scripts/gcc-16.1.0.sh
+++ b/scripts/gcc-16.1.0.sh
@@ -60,6 +60,8 @@ PKG_PATCHES=(
 	gcc/gcc-12-replace-abort-with-fancy_abort.patch
 	gcc/gcc-13-mcf-sjlj-avoid-infinite-recursion.patch
 	gcc/gcc-16.1.0-libstdcxx-atomic-check.patch
+	gcc/fix-under-aligned-indirect-AVX-argument-return-stack-slots-win64.patch
+	gcc/return-256-512-bit-vectors-in-registers-x86_64-MS-ABI.patch
 )
 
 #


### PR DESCRIPTION
This PR ontains two patches for gcc, fixing #756:
- [i386: return 256/512-bit vectors in registers for x86_64 MS ABI [PR89597]](https://gcc.gnu.org/cgit/gcc/patch/?id=ae4efe523b80321fd885412fbc98e2102abc6178)
- [x86: fix under-aligned indirect AVX argument/return stack slots on win64 [PR54412]](https://gcc.gnu.org/cgit/gcc/patch/?id=77b2eaf09c77bf2dddcb8c35ee8bc9cc99e2f93c)

Use the testcase from https://stackoverflow.com/questions/30926241/wrapper-for-m256-producing-segmentation-fault-with-constructor-windows-64:

```c
#include <immintrin.h>

void foo(__m256 x) {}

int main()
{
    __m256 r = _mm256_set1_ps(0.0f);
    foo(r);
}
```

Test result:
```
PS E:\Sources\build\mingw\x86_64-1610-mcf-seh-msvcrt-rt_v15\mingw64\bin> gcc a.c -mavx
PS E:\Sources\build\mingw\x86_64-1610-mcf-seh-msvcrt-rt_v15\mingw64\bin> gdb a.exe
......
Reading symbols from a.exe...
(gdb) r
Starting program: E:\Sources\build\mingw\x86_64-1610-mcf-seh-msvcrt-rt_v15\mingw64\bin\a.exe
[New Thread 36580.0x5cc0]
[New Thread 36580.0x4ddc]
[New Thread 36580.0x7b0c]

Thread 1 received signal SIGSEGV, Segmentation fault.
0x00007ff7df331502 in main ()
(gdb) exit
A debugging session is active.

        Inferior 1 [process 36580] will be killed.

Quit anyway? (y or n) y
PS E:\Sources\build\mingw\x86_64-1610-mcf-seh-msvcrt-rt_v15\mingw64\bin> .\gcc.exe a.c -mavx
PS E:\Sources\build\mingw\x86_64-1610-mcf-seh-msvcrt-rt_v15\mingw64\bin> gdb a.exe
......
Reading symbols from a.exe...
(gdb) r
Starting program: E:\Sources\build\mingw\x86_64-1610-mcf-seh-msvcrt-rt_v15\mingw64\bin\a.exe
[New Thread 2496.0x11d8]
[New Thread 2496.0x8aac]
[Thread 2496.0x54d0 exited with code 0]
[Thread 2496.0x11d8 exited with code 0]
[Inferior 1 (process 2496) exited normally]
(gdb) quit

PS E:\Sources\build\mingw\x86_64-1610-mcf-seh-msvcrt-rt_v15\mingw64\bin> gcc -v
Using built-in specs.
COLLECT_GCC=D:\mingw64\bin\gcc.exe
COLLECT_LTO_WRAPPER=E:/Programs/mingw64/bin/../libexec/gcc/x86_64-w64-mingw32/16.1.0/lto-wrapper.exe
Target: x86_64-w64-mingw32
Configured with: ../../../src/gcc-16.1.0/configure --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --prefix=/mingw64 --with-sysroot=/c/buildroot/x86_64-1610-mcf-seh-ucrt-rt_v14-rev0/mingw64 --enable-host-shared --disable-multilib --enable-languages=c,c++,fortran,lto --enable-libstdcxx-time=yes --enable-threads=mcf --enable-tls --enable-libgomp --enable-libatomic --enable-lto --enable-graphite --enable-checking=release --enable-mingw-wildcard --enable-fully-dynamic-string --enable-version-specific-runtime-libs --enable-libstdcxx-filesystem-ts=yes --disable-libssp --disable-libstdcxx-pch --disable-libstdcxx-debug --enable-bootstrap --disable-rpath --disable-win32-registry --disable-nls --disable-werror --disable-symvers --with-gnu-as --with-gnu-ld --with-arch=nocona --with-tune=core2 --with-libiconv --with-system-zlib --with-gmp=/c/buildroot/prerequisites/x86_64-w64-mingw32-static --with-mpfr=/c/buildroot/prerequisites/x86_64-w64-mingw32-static --with-mpc=/c/buildroot/prerequisites/x86_64-w64-mingw32-static --with-isl=/c/buildroot/prerequisites/x86_64-w64-mingw32-static --with-pkgversion='x86_64-mcf-seh-rev0, Built by MinGW-Builds project' --with-bugurl=https://github.com/niXman/mingw-builds LD_FOR_TARGET=/c/buildroot/x86_64-1610-mcf-seh-ucrt-rt_v14-rev0/mingw64/bin/ld.exe --with-boot-ldflags='-pipe -fno-ident -L/c/buildroot/x86_64-1610-mcf-seh-ucrt-rt_v14-rev0/mingw64/opt/lib -L/c/buildroot/prerequisites/x86_64-zlib-static/lib -L/c/buildroot/prerequisites/x86_64-w64-mingw32-static/lib  -Wl,--disable-dynamicbase -static-libstdc++ -static-libgcc'
Thread model: mcf
Supported LTO compression algorithms: zlib
gcc version 16.1.0 (x86_64-mcf-seh-rev0, Built by MinGW-Builds project)
PS E:\Sources\build\mingw\x86_64-1610-mcf-seh-msvcrt-rt_v15\mingw64\bin> .\gcc.exe -v
Using built-in specs.
COLLECT_GCC=E:\Sources\build\mingw\x86_64-1610-mcf-seh-msvcrt-rt_v15\mingw64\bin\gcc.exe
COLLECT_LTO_WRAPPER=E:/Sources/build/mingw/x86_64-1610-mcf-seh-msvcrt-rt_v15/mingw64/bin/../libexec/gcc/x86_64-w64-mingw32/16.1.0/lto-wrapper.exe
Target: x86_64-w64-mingw32
Configured with: ../../../src/gcc-16.1.0/configure --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --prefix=/mingw64 --with-sysroot=/e/Sources/build/mingw/x86_64-1610-mcf-seh-msvcrt-rt_v15/mingw64 --enable-host-shared --disable-multilib --enable-languages=c,c++,fortran,lto --enable-libstdcxx-time=yes --enable-threads=mcf --enable-tls --enable-libgomp --enable-libatomic --enable-lto --enable-graphite --enable-checking=release --enable-mingw-wildcard --enable-fully-dynamic-string --enable-version-specific-runtime-libs --enable-libstdcxx-filesystem-ts=yes --disable-libssp --disable-libstdcxx-pch --disable-libstdcxx-debug --disable-bootstrap --disable-rpath --disable-win32-registry --disable-nls --disable-werror --disable-symvers --with-gnu-as --with-gnu-ld --with-arch=nocona --with-tune=core2 --with-libiconv --with-system-zlib --with-gmp=/e/Sources/build/mingw/prerequisites/x86_64-w64-mingw32-static --with-mpfr=/e/Sources/build/mingw/prerequisites/x86_64-w64-mingw32-static --with-mpc=/e/Sources/build/mingw/prerequisites/x86_64-w64-mingw32-static --with-isl=/e/Sources/build/mingw/prerequisites/x86_64-w64-mingw32-static --with-pkgversion='x86_64-mcf-seh, Built by MinGW-Builds project' --with-bugurl=https://github.com/niXman/mingw-builds LD_FOR_TARGET=/e/Sources/build/mingw/x86_64-1610-mcf-seh-msvcrt-rt_v15/mingw64/bin/ld.exe --with-boot-ldflags='-pipe -fno-ident -L/e/Sources/build/mingw/x86_64-1610-mcf-seh-msvcrt-rt_v15/mingw64/opt/lib -L/e/Sources/build/mingw/prerequisites/x86_64-zlib-static/lib -L/e/Sources/build/mingw/prerequisites/x86_64-w64-mingw32-static/lib  -Wl,--disable-dynamicbase -static-libstdc++ -static-libgcc'
Thread model: mcf
Supported LTO compression algorithms: zlib
gcc version 16.1.0 (x86_64-mcf-seh, Built by MinGW-Builds project)
```

I have only tested the patches with gcc-16.1.0 currently.

