### PR TITLE
CI: Download sources first and share them across all variants

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -2,6 +2,10 @@ name: x86_64 and i686 release builds
 
 on: [push, pull_request]
 
+env:
+  MINGW_BUILDS_GCC_VERSION: "16.1.0"
+  MINGW_BUILDS_RT_VERSION: "v14"
+
 jobs:
   build:
     name: ${{ matrix.config.name }}
@@ -9,57 +13,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-        - {
-            name: "x86_64 posix seh msvcrt",
-            artifact: "x86_64-16.1.0-release-posix-seh-msvcrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --logviewer-command=cat"
-          }
-        - {
-            name: "x86_64 posix seh ucrt",
-            artifact: "x86_64-16.1.0-release-posix-seh-ucrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=posix --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
-          }
-        - {
-            name: "x86_64 win32 seh msvcrt",
-            artifact: "x86_64-16.1.0-release-win32-seh-msvcrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --logviewer-command=cat"
-          }
-        - {
-            name: "x86_64 win32 seh ucrt",
-            artifact: "x86_64-16.1.0-release-win32-seh-ucrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=win32 --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
-          }
-        - {
-            name: "x86_64 mcf seh ucrt",
-            artifact: "x86_64-16.1.0-release-mcf-seh-ucrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=mcf --exceptions=seh --arch=x86_64 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
-          }
-        - {
-            name: "i686 posix dwarf msvcrt",
-            artifact: "i686-16.1.0-release-posix-dwarf-msvcrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --logviewer-command=cat"
-          }
-        - {
-            name: "i686 posix dwarf ucrt",
-            artifact: "i686-16.1.0-release-posix-dwarf-ucrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=posix --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
-          }
-        - {
-            name: "i686 win32 dwarf msvcrt",
-            artifact: "i686-16.1.0-release-win32-dwarf-msvcrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --logviewer-command=cat"
-          }
-        - {
-            name: "i686 win32 dwarf ucrt",
-            artifact: "i686-16.1.0-release-win32-dwarf-ucrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=win32 --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
-          }
-        - {
-            name: "i686 mcf dwarf ucrt",
-            artifact: "i686-16.1.0-release-mcf-dwarf-ucrt-rt_v14-rev0.7z",
-            build_cmd: "--mode=gcc-16.1.0 --buildroot=/c/buildroot --jobs=4 --rev=0 --rt-version=v14 --threads=mcf --exceptions=dwarf --arch=i686 --bin-compress --enable-languages=c,c++,fortran --with-default-msvcrt=ucrt --logviewer-command=cat"
-          }
+        arch: [x86_64, i686]
+        threads: [posix, win32, mcf]
+        exceptions: [seh, dwarf]
+        msvcrt: [msvcrt, ucrt]
+        exclude:
+          - arch: x86_64
+            exceptions: dwarf
+          - arch: i686
+            exceptions: seh
+          - threads: mcf
+            msvcrt: msvcrt
 
     steps:
     - uses: actions/checkout@v3
@@ -70,13 +34,26 @@ jobs:
 
     - name: Build
       shell: msys2 {0}
-      run: ./build ${{ matrix.config.build_cmd }}
+      run: >-
+        ./build
+        --mode=gcc-$MINGW_BUILDS_GCC_VERSION
+        --buildroot=/c/buildroot
+        --jobs=4
+        --rev=0
+        --with-default-msvcrt=${{ matrix.msvcrt }}
+        --rt-version=$MINGW_BUILDS_RT_VERSION
+        --threads=${{ matrix.threads }}
+        --exceptions=${{ matrix.exceptions }}
+        --arch=${{ matrix.arch }}
+        --bin-compress
+        --enable-languages=c,c++,fortran
+        --logviewer-command=cat
 
     - name: Upload
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
-        path: c:/buildroot/archives/${{ matrix.config.artifact }}
-        name: ${{ matrix.config.artifact }}
+        name: ${{ matrix.arch }}-${{ matrix.threads }}-${{ matrix.exceptions }}-${{ matrix.msvcrt }}
+        path: c:/buildroot/archives/
 
   release:
     if: contains(github.ref, 'tags/v')
@@ -84,101 +61,14 @@ jobs:
     needs: build
 
     steps:
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1.0.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
-
-    - name: Store Release url
-      run: |
-        echo "${{ steps.create_release.outputs.upload_url }}" > ./upload_url
-
-    - uses: actions/upload-artifact@v4
-      with:
-        path: ./upload_url
-        name: upload_url
-
-  publish:
-    if: contains(github.ref, 'tags/v')
-    name: ${{ matrix.config.name }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-        - {
-            name: "x86_64 posix seh msvcrt",
-            artifact: "x86_64-16.1.0-release-posix-seh-msvcrt-rt_v14-rev0.7z"
-          }
-        - {
-            name: "x86_64 posix seh ucrt",
-            artifact: "x86_64-16.1.0-release-posix-seh-ucrt-rt_v14-rev0.7z"
-          }
-        - {
-            name: "x86_64 win32 seh msvcrt",
-            artifact: "x86_64-16.1.0-release-win32-seh-msvcrt-rt_v14-rev0.7z"
-          }
-        - {
-            name: "x86_64 win32 seh ucrt",
-            artifact: "x86_64-16.1.0-release-win32-seh-ucrt-rt_v14-rev0.7z"
-          }
-        - {
-            name: "x86_64 mcf seh ucrt",
-            artifact: "x86_64-16.1.0-release-mcf-seh-ucrt-rt_v14-rev0.7z"
-          }
-        - {
-            name: "i686 posix dwarf msvcrt",
-            artifact: "i686-16.1.0-release-posix-dwarf-msvcrt-rt_v14-rev0.7z"
-          }
-        - {
-            name: "i686 posix dwarf ucrt",
-            artifact: "i686-16.1.0-release-posix-dwarf-ucrt-rt_v14-rev0.7z"
-          }
-        - {
-            name: "i686 win32 dwarf msvcrt",
-            artifact: "i686-16.1.0-release-win32-dwarf-msvcrt-rt_v14-rev0.7z"
-          }
-        - {
-            name: "i686 win32 dwarf ucrt",
-            artifact: "i686-16.1.0-release-win32-dwarf-ucrt-rt_v14-rev0.7z"
-          }
-        - {
-            name: "i686 mcf dwarf ucrt",
-            artifact: "i686-16.1.0-release-mcf-dwarf-ucrt-rt_v14-rev0.7z"
-          }
-
-    needs: release
-
-    steps:
     - name: Download artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
-        name: ${{ matrix.config.artifact }}
         path: ./
-
-    - name: Download URL
-      uses: actions/download-artifact@v4
-      with:
-        name: upload_url
-        path: ./
-    - id: set_upload_url
-      run: |
-        upload_url=`cat ./upload_url`
-        echo upload_url=$upload_url >> $GITHUB_OUTPUT
+        merge-multiple: true
 
     - name: Upload to Release
       id: upload_to_release
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v1
       with:
-        upload_url: ${{ steps.set_upload_url.outputs.upload_url }}
-        asset_path: ./${{ matrix.config.artifact }}
-        asset_name: ${{ matrix.config.artifact }}
-        asset_content_type: application/x-gtar
+        files: "*.7z"

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -34,12 +34,16 @@ jobs:
         --logviewer-command=cat
         --fetch-only
 
+    - name: Compress sources
+      run: 7z a src.7z src
+      working-directory: c:/buildroot
+
     - name: Upload sources
       uses: actions/upload-artifact@v7
       with:
-        name: src
-        path: c:/buildroot/src/
-        include-hidden-files: true
+        path: c:/buildroot/src.7z
+        compression-level: 0
+        archive: false
 
   build:
     name: ${{ matrix.arch }}-${{ matrix.threads }}-${{ matrix.exceptions }}-${{ matrix.msvcrt }}
@@ -67,15 +71,15 @@ jobs:
       with:
         update: true
 
-    - name: Prepare directories
-      shell: msys2 {0}
-      run: mkdir -p /c/buildroot/src
-
     - name: Download sources
       uses: actions/download-artifact@v8
       with:
-        name: src
-        path: c:/buildroot/src/
+        name: src.7z
+        path: c:/buildroot
+
+    - name: Extract sources
+      run: 7z x src.7z
+      working-directory: c:/buildroot
 
     - name: Build
       shell: msys2 {0}

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -7,9 +7,44 @@ env:
   MINGW_BUILDS_RT_VERSION: "v14"
 
 jobs:
-  build:
-    name: ${{ matrix.config.name }}
+  download:
     runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: msys2/setup-msys2@v2
+      with:
+        update: true
+
+    - name: Download sources
+      shell: msys2 {0}
+      run: >-
+        ./build
+        --mode=gcc-$MINGW_BUILDS_GCC_VERSION
+        --buildroot=/c/buildroot
+        --jobs=4
+        --rev=0
+        --with-default-msvcrt=ucrt
+        --rt-version=$MINGW_BUILDS_RT_VERSION
+        --threads=mcf
+        --exceptions=seh
+        --arch=x86_64
+        --bin-compress
+        --enable-languages=c,c++,fortran
+        --logviewer-command=cat
+        --fetch-only
+
+    - name: Upload sources
+      uses: actions/upload-artifact@v7
+      with:
+        name: src
+        path: c:/buildroot/src/
+        include-hidden-files: true
+
+  build:
+    name: ${{ matrix.arch }}-${{ matrix.threads }}-${{ matrix.exceptions }}-${{ matrix.msvcrt }}
+    runs-on: windows-latest
+    needs: download
     strategy:
       fail-fast: false
       matrix:
@@ -32,6 +67,16 @@ jobs:
       with:
         update: true
 
+    - name: Prepare directories
+      shell: msys2 {0}
+      run: mkdir -p /c/buildroot/src
+
+    - name: Download sources
+      uses: actions/download-artifact@v8
+      with:
+        name: src
+        path: c:/buildroot/src/
+
     - name: Build
       shell: msys2 {0}
       run: >-
@@ -52,7 +97,7 @@ jobs:
     - name: Upload
       uses: actions/upload-artifact@v7
       with:
-        name: ${{ matrix.arch }}-${{ matrix.threads }}-${{ matrix.exceptions }}-${{ matrix.msvcrt }}
+        name: bin-${{ matrix.arch }}-${{ matrix.threads }}-${{ matrix.exceptions }}-${{ matrix.msvcrt }}
         path: c:/buildroot/archives/
 
   release:
@@ -64,6 +109,7 @@ jobs:
     - name: Download artifact
       uses: actions/download-artifact@v8
       with:
+        pattern: "bin-*"
         path: ./
         merge-multiple: true
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -10,7 +10,7 @@ jobs:
   download:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
 
     - uses: msys2/setup-msys2@v2
       with:
@@ -65,7 +65,7 @@ jobs:
             msvcrt: msvcrt
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
 
     - uses: msys2/setup-msys2@v2
       with:

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -35,7 +35,7 @@ jobs:
         --fetch-only
 
     - name: Compress sources
-      run: 7z a src.7z src
+      run: 7z a src.7z src "-xr!.git"
       working-directory: c:/buildroot
 
     - name: Upload sources


### PR DESCRIPTION
Change the CI workflow to download source files first and share them across all variants. This reduces load on servers and improves reliability.

Also:
- Simplify the GitHub Actions file. It now matches the one in niXman/mingw-builds-binaries more closely.
- Upgrade actions/checkout to v7.